### PR TITLE
feat: add mock stationery web store agent (A2A + x402 payments)

### DIFF
--- a/onchain-agents/coding-labs/compose.yaml
+++ b/onchain-agents/coding-labs/compose.yaml
@@ -172,6 +172,8 @@ services:
       - SOMNIA_AGENT_URL=http://somnia-agent:4001
       - SONIC_AGENT_URL=http://sonic-agent:4002
       - MIDNIGHT_AGENT_URL=http://midnight-agent:4003
+      - STORE_AGENT_URL=http://store-agent:4004
+      - PAYMENT_AGENT_URL=http://payment-agent:4005
     volumes:
       # Mount config.toml for the registry to read
       - ./config.toml:/app/config.toml:ro
@@ -302,6 +304,64 @@ services:
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------
+  # Store Agent - Mock stationery web store (x402 payments)
+  # ---------------------------------------------------------------------------
+  store-agent:
+    build:
+      context: .
+      dockerfile: packages/store-agent/Containerfile
+    container_name: store-agent
+    ports:
+      - '${STORE_AGENT_PORT:-4004}:${STORE_AGENT_PORT:-4004}'
+    env_file:
+      - .env.generated
+    environment:
+      - NODE_ENV=development
+      - STORE_AGENT_HOST=0.0.0.0
+    volumes:
+      - ./config.toml:/app/config.toml:ro
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "require(''http'').get(''http://localhost:4004/health'',r=>process.exit(r.statusCode===200?0:1)).on(''error'',()=>process.exit(1))"',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Payment Agent - x402 payment facilitator and buyer-side agent
+  # ---------------------------------------------------------------------------
+  payment-agent:
+    build:
+      context: .
+      dockerfile: packages/payment-agent/Containerfile
+    container_name: payment-agent
+    ports:
+      - '${PAYMENT_AGENT_PORT:-4005}:${PAYMENT_AGENT_PORT:-4005}'
+    env_file:
+      - .env.generated
+    environment:
+      - NODE_ENV=development
+      - PAYMENT_AGENT_HOST=0.0.0.0
+    volumes:
+      - ./config.toml:/app/config.toml:ro
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "require(''http'').get(''http://localhost:4005/health'',r=>process.exit(r.statusCode===200?0:1)).on(''error'',()=>process.exit(1))"',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
   # OpenCode Web - Frontend + Backend with wallet connection and A2A routing
   # ---------------------------------------------------------------------------
   # Runs both the OpenCode server (with A2A plugin) and serves the static frontend.
@@ -335,6 +395,8 @@ services:
       - somnia-agent
       - sonic-agent
       - midnight-agent
+      - store-agent
+      - payment-agent
     healthcheck:
       test:
         ['CMD', 'wget', '-q', '--spider', 'http://127.0.0.1:8080/global/health']
@@ -387,6 +449,10 @@ services:
 #                                           │
 #   somnia-agent ◄──────────────────────────┤
 #                                           │
+#   store-agent ◄───────────────────────────┤
+#                                           │
+#   payment-agent ◄─────────────────────────┤
+#                                           │
 #   agent-registry ◄────────────────────────┤
 #                                           │
 #                                           ▼
@@ -411,6 +477,8 @@ services:
 #   Registry:      http://localhost:4000
 #   Somnia:        http://localhost:4001
 #   Midnight:      http://localhost:4003
+#   Store:         http://localhost:4004
+#   Payment:       http://localhost:4005
 #   OpenCode:      http://localhost:3000
 #
 # With login page:

--- a/onchain-agents/coding-labs/config.toml
+++ b/onchain-agents/coding-labs/config.toml
@@ -39,6 +39,14 @@ port = 4002
 host = "localhost"
 port = 4003
 
+[default.services.store-agent]
+host = "localhost"
+port = 4004
+
+[default.services.payment-agent]
+host = "localhost"
+port = 4005
+
 [default.services.midnight-mcp]
 host = "localhost"
 port = 4010
@@ -83,6 +91,22 @@ description = "Privacy-preserving blockchain with zero-knowledge proofs and Comp
 service = "midnight-agent"
 chain_id = 0
 keywords = ["midnight", "privacy", "zk", "zero-knowledge", "compact", "confidential"]
+enabled = true
+
+[default.agents.store]
+name = "Store Agent"
+description = "Mock stationery web store. Browse, search, and purchase items with crypto payments via x402."
+service = "store-agent"
+chain_id = 0
+keywords = ["store", "shop", "buy", "purchase", "stationery", "notebook", "pen", "pencil", "eraser", "catalog", "browse", "order", "cart"]
+enabled = true
+
+[default.agents.payment]
+name = "Payment Agent"
+description = "x402 payment facilitator and buyer-side agent. Handles USDC payments, verification, and settlement for purchases."
+service = "payment-agent"
+chain_id = 0
+keywords = ["pay", "payment", "settle", "x402", "usdc", "transfer", "facilitator", "checkout", "invoice"]
 enabled = true
 
 # -----------------------------------------------------------------------------
@@ -168,6 +192,26 @@ proof_server = "7.0.0"
 indexer = "3.0.0"
 
 # -----------------------------------------------------------------------------
+# x402 Payment Protocol Configuration
+# -----------------------------------------------------------------------------
+# Configuration for x402-based payments between store and payment agents.
+# Facilitator URL can be changed to switch between testnet and mainnet.
+
+[default.x402]
+facilitator_url = "https://x402.org/facilitator"
+default_network = "eip155:84532"
+
+# Store wallet address (receives payments) - replace with actual address
+[default.x402.store]
+wallet_address = "0x0000000000000000000000000000000000000000"
+
+# USDC contract addresses per network (CAIP-2 identifiers)
+[default.x402.assets.usdc]
+"eip155:84532" = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+"eip155:8453" = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+"eip155:1" = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+# -----------------------------------------------------------------------------
 # LLM Configuration
 # -----------------------------------------------------------------------------
 # Define reusable LLM providers, then assign them to components.
@@ -206,7 +250,7 @@ opencode = "vertex-anthropic"
 [default.a2a]
 # Explicit list of agent IDs enabled by default
 # These must match agent IDs defined in [default.agents.*]
-default_agents = ["somnia", "sonic", "midnight"]
+default_agents = ["somnia", "sonic", "midnight", "store", "payment"]
 
 # -----------------------------------------------------------------------------
 # Authentication (IAP user whitelist)
@@ -244,6 +288,12 @@ host = "0.0.0.0"
 host = "0.0.0.0"
 
 [production.services.midnight-mcp]
+host = "0.0.0.0"
+
+[production.services.store-agent]
+host = "0.0.0.0"
+
+[production.services.payment-agent]
 host = "0.0.0.0"
 
 [production.services.evm-mcp]

--- a/onchain-agents/coding-labs/packages/shared/package.json
+++ b/onchain-agents/coding-labs/packages/shared/package.json
@@ -20,6 +20,10 @@
     "./llm": {
       "import": "./dist/llm/index.js",
       "types": "./dist/llm/index.d.ts"
+    },
+    "./x402": {
+      "import": "./dist/x402/index.js",
+      "types": "./dist/x402/index.d.ts"
     }
   },
   "scripts": {

--- a/onchain-agents/coding-labs/packages/shared/src/x402/index.ts
+++ b/onchain-agents/coding-labs/packages/shared/src/x402/index.ts
@@ -1,0 +1,6 @@
+export type {
+  PaymentOption,
+  PaymentRequired,
+  OrderInfo,
+  PaymentResult,
+} from './types.js';

--- a/onchain-agents/coding-labs/packages/shared/src/x402/types.ts
+++ b/onchain-agents/coding-labs/packages/shared/src/x402/types.ts
@@ -1,0 +1,66 @@
+/**
+ * x402 Payment Protocol Types
+ *
+ * Shared types used by the store agent and payment agent
+ * for x402 protocol-based payments.
+ */
+
+/**
+ * A payment option accepted by a seller
+ */
+export interface PaymentOption {
+  /** Payment scheme (e.g., "exact") */
+  scheme: string;
+  /** Network identifier in CAIP-2 format (e.g., "eip155:84532") */
+  network: string;
+  /** Price as human-readable string (e.g., "$2.50") */
+  price: string;
+  /** Seller's wallet address to receive payment */
+  payTo: string;
+  /** Asset contract address (e.g., USDC) */
+  asset?: string;
+}
+
+/**
+ * x402 PaymentRequired response
+ */
+export interface PaymentRequired {
+  /** List of accepted payment options */
+  accepts: PaymentOption[];
+  /** Description of what is being paid for */
+  description: string;
+  /** MIME type of the response */
+  mimeType?: string;
+}
+
+/**
+ * Order information from the store agent
+ */
+export interface OrderInfo {
+  /** Unique order identifier */
+  orderId: string;
+  /** Item being purchased */
+  item: {
+    id: string;
+    name: string;
+    priceUSDC: string;
+  };
+  /** x402 payment requirements */
+  paymentRequired: PaymentRequired;
+  /** Order status */
+  status: 'pending_payment' | 'paid' | 'confirmed' | 'cancelled';
+}
+
+/**
+ * Result of a payment settlement
+ */
+export interface PaymentResult {
+  /** Whether the payment was successful */
+  success: boolean;
+  /** Transaction hash (if settled) */
+  txHash?: string;
+  /** Network the payment was settled on */
+  network?: string;
+  /** Error message (if failed) */
+  error?: string;
+}

--- a/onchain-agents/coding-labs/packages/store-agent/Containerfile
+++ b/onchain-agents/coding-labs/packages/store-agent/Containerfile
@@ -1,0 +1,39 @@
+# Build stage
+FROM node:22-slim AS builder
+WORKDIR /app
+
+RUN npm install -g pnpm@9
+
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY tsconfig.base.json ./
+COPY packages/shared/package.json packages/shared/
+COPY packages/store-agent/package.json packages/store-agent/
+
+RUN pnpm install --frozen-lockfile
+
+COPY packages/shared packages/shared
+COPY packages/store-agent packages/store-agent
+COPY config.toml ./
+
+RUN pnpm --filter @coding-labs/shared build
+RUN pnpm --filter @coding-labs/store-agent build
+
+# Runtime stage
+FROM node:22-slim
+WORKDIR /app
+
+COPY --from=builder /app/packages/store-agent/dist ./dist
+COPY --from=builder /app/packages/store-agent/package.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages/shared/dist ./node_modules/@coding-labs/shared/dist
+COPY --from=builder /app/packages/shared/package.json ./node_modules/@coding-labs/shared/
+
+COPY packages/store-agent/SKILLS.md ./SKILLS.md
+
+ENV NODE_ENV=production
+EXPOSE 4004
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:4004/health || exit 1
+
+CMD ["node", "dist/index.js"]

--- a/onchain-agents/coding-labs/packages/store-agent/SKILLS.md
+++ b/onchain-agents/coding-labs/packages/store-agent/SKILLS.md
@@ -1,0 +1,39 @@
+# Store Agent Skills Reference
+
+This document describes the Store Agent's capabilities for the mock stationery web store.
+
+## Overview
+
+The Store Agent manages a catalog of stationery items and handles the purchase flow using the x402 payment protocol.
+
+## Skills
+
+### browse
+Browse and search the stationery catalog. Supports category filtering and text search.
+- Categories: notebooks, pens, pencils, erasers, markers, paper, accessories
+- Returns formatted table with item names, prices, and stock status
+
+### item-detail
+Get detailed information about a specific item including full description, price, and availability.
+
+### purchase
+Initiate a purchase. Creates an order and returns x402 PaymentRequired information including:
+- Network (CAIP-2 format, e.g., eip155:84532 for Base Sepolia)
+- Scheme (exact)
+- Payment destination address
+- USDC asset contract address
+- Amount in USDC
+
+### confirm
+Confirm a purchase after payment. Requires order ID and transaction hash.
+
+## x402 Payment Integration
+
+The store uses the x402 protocol (HTTP 402 Payment Required) for payments:
+1. User requests a purchase → store returns PaymentRequired with USDC payment details
+2. User pays via the Payment Agent → receives transaction hash
+3. User confirms purchase with transaction hash → store verifies and confirms order
+
+## Catalog
+
+The store maintains a hardcoded catalog of stationery items with prices in USDC (6 decimal stablecoin).

--- a/onchain-agents/coding-labs/packages/store-agent/package.json
+++ b/onchain-agents/coding-labs/packages/store-agent/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@coding-labs/store-agent",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "pnpm exec tsc",
+    "start": "node dist/index.js",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm exec tsc --noEmit"
+  },
+  "dependencies": {
+    "@a2a-js/sdk": "^0.3.10",
+    "@coding-labs/shared": "workspace:*",
+    "express": "^4.21.0",
+    "uuid": "^11.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.13.0",
+    "@types/uuid": "^10.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/onchain-agents/coding-labs/packages/store-agent/src/agent-card.ts
+++ b/onchain-agents/coding-labs/packages/store-agent/src/agent-card.ts
@@ -1,0 +1,84 @@
+import type { AgentCard } from '@a2a-js/sdk';
+
+const PORT = process.env.STORE_AGENT_PORT || 4004;
+const HOST = process.env.STORE_AGENT_HOST || 'localhost';
+
+export const storeAgentCard: AgentCard = {
+  name: 'Store Agent',
+  description:
+    'Mock stationery web store. Browse a catalog of notebooks, pens, pencils, and accessories. Purchase items using crypto payments via the x402 protocol.',
+  url: `http://${HOST}:${PORT}/`,
+  protocolVersion: '0.3.0',
+  provider: {
+    organization: 'Coding Labs',
+    url: 'https://github.com/dcentral-labs/onchain-agents',
+  },
+  version: '0.1.0',
+  capabilities: {
+    streaming: true,
+    pushNotifications: false,
+    stateTransitionHistory: true,
+  },
+  defaultInputModes: ['text'],
+  defaultOutputModes: ['text'],
+  skills: [
+    {
+      id: 'browse',
+      name: 'Browse Catalog',
+      description:
+        'Browse and search the stationery catalog. List all items, filter by category, or search by name.',
+      tags: ['store', 'catalog', 'browse', 'search', 'stationery'],
+      examples: [
+        'Show me all items',
+        'What notebooks do you have?',
+        'List pens',
+        'Search for pencils',
+        'What do you sell?',
+      ],
+      inputModes: ['text'],
+      outputModes: ['text'],
+    },
+    {
+      id: 'item-detail',
+      name: 'Item Details',
+      description:
+        'Get detailed information about a specific stationery item including price and availability.',
+      tags: ['store', 'item', 'detail', 'price'],
+      examples: [
+        'Tell me about the spiral notebook',
+        'How much is the gel pen set?',
+        'Details on the leather journal',
+      ],
+      inputModes: ['text'],
+      outputModes: ['text'],
+    },
+    {
+      id: 'purchase',
+      name: 'Purchase Item',
+      description:
+        'Initiate a purchase for a stationery item. Returns order details and x402 payment requirements.',
+      tags: ['store', 'buy', 'purchase', 'order', 'x402'],
+      examples: [
+        'Buy the spiral notebook',
+        'I want to purchase the gel pen set',
+        'Order a mechanical pencil',
+      ],
+      inputModes: ['text'],
+      outputModes: ['text'],
+    },
+    {
+      id: 'confirm',
+      name: 'Confirm Purchase',
+      description:
+        'Confirm a purchase after payment has been made. Provide the transaction hash to verify payment.',
+      tags: ['store', 'confirm', 'order', 'receipt'],
+      examples: [
+        'Confirm my purchase with tx 0x123...',
+        'Verify payment for order ord_abc123',
+      ],
+      inputModes: ['text'],
+      outputModes: ['text'],
+    },
+  ],
+  supportsAuthenticatedExtendedCard: false,
+};

--- a/onchain-agents/coding-labs/packages/store-agent/src/catalog.ts
+++ b/onchain-agents/coding-labs/packages/store-agent/src/catalog.ts
@@ -1,0 +1,144 @@
+export interface StationeryItem {
+  id: string;
+  name: string;
+  description: string;
+  category: 'notebooks' | 'pens' | 'pencils' | 'erasers' | 'markers' | 'paper' | 'accessories';
+  priceUSDC: string;    // Human-readable price, e.g., "2.50"
+  priceRaw: string;     // Raw USDC amount in smallest unit (6 decimals), e.g., "2500000"
+  inStock: boolean;
+}
+
+export const CATALOG: StationeryItem[] = [
+  {
+    id: 'notebook-spiral',
+    name: 'Spiral Notebook',
+    description: 'Classic 100-page spiral-bound notebook. College ruled. Perfect for notes and sketches.',
+    category: 'notebooks',
+    priceUSDC: '2.50',
+    priceRaw: '2500000',
+    inStock: true,
+  },
+  {
+    id: 'notebook-leather',
+    name: 'Leather Journal',
+    description: 'Premium leather-bound journal with 200 blank pages. Great for journaling.',
+    category: 'notebooks',
+    priceUSDC: '12.00',
+    priceRaw: '12000000',
+    inStock: true,
+  },
+  {
+    id: 'pen-gel-set',
+    name: 'Gel Pen Set (5-pack)',
+    description: 'Smooth-writing gel pens in black, blue, red, green, and purple.',
+    category: 'pens',
+    priceUSDC: '5.00',
+    priceRaw: '5000000',
+    inStock: true,
+  },
+  {
+    id: 'pen-fountain',
+    name: 'Classic Fountain Pen',
+    description: 'Elegant fountain pen with fine nib. Includes ink cartridge.',
+    category: 'pens',
+    priceUSDC: '15.00',
+    priceRaw: '15000000',
+    inStock: true,
+  },
+  {
+    id: 'pencil-mechanical',
+    name: 'Mechanical Pencil (0.5mm)',
+    description: 'Precision mechanical pencil with rubber grip. Includes lead refills.',
+    category: 'pencils',
+    priceUSDC: '1.50',
+    priceRaw: '1500000',
+    inStock: true,
+  },
+  {
+    id: 'pencil-set-hb',
+    name: 'HB Pencil Set (12-pack)',
+    description: 'Standard HB graphite pencils. Pre-sharpened and ready to use.',
+    category: 'pencils',
+    priceUSDC: '3.00',
+    priceRaw: '3000000',
+    inStock: true,
+  },
+  {
+    id: 'eraser-pack',
+    name: 'Eraser Pack (3-pack)',
+    description: 'Soft white erasers that erase cleanly without smudging.',
+    category: 'erasers',
+    priceUSDC: '0.75',
+    priceRaw: '750000',
+    inStock: true,
+  },
+  {
+    id: 'highlighter-set',
+    name: 'Highlighter Set (4-pack)',
+    description: 'Bright highlighters in yellow, pink, green, and orange. Chisel tip.',
+    category: 'markers',
+    priceUSDC: '3.00',
+    priceRaw: '3000000',
+    inStock: true,
+  },
+  {
+    id: 'paper-a4-ream',
+    name: 'A4 Paper Ream (500 sheets)',
+    description: 'Premium white A4 paper, 80gsm. Suitable for printing and writing.',
+    category: 'paper',
+    priceUSDC: '8.00',
+    priceRaw: '8000000',
+    inStock: true,
+  },
+  {
+    id: 'sticky-notes',
+    name: 'Sticky Notes (3x3 inch, 100 sheets)',
+    description: 'Self-adhesive notes in bright yellow. Repositionable.',
+    category: 'paper',
+    priceUSDC: '1.25',
+    priceRaw: '1250000',
+    inStock: true,
+  },
+  {
+    id: 'ruler-30cm',
+    name: 'Clear Ruler (30cm)',
+    description: 'Transparent plastic ruler with metric and imperial markings.',
+    category: 'accessories',
+    priceUSDC: '0.50',
+    priceRaw: '500000',
+    inStock: true,
+  },
+  {
+    id: 'scissors-office',
+    name: 'Office Scissors',
+    description: 'Stainless steel scissors with comfortable grip. 8-inch.',
+    category: 'accessories',
+    priceUSDC: '4.00',
+    priceRaw: '4000000',
+    inStock: true,
+  },
+];
+
+// Helper functions
+export function findItemById(id: string): StationeryItem | undefined {
+  return CATALOG.find(item => item.id === id);
+}
+
+export function findItemByName(name: string): StationeryItem | undefined {
+  const lower = name.toLowerCase();
+  return CATALOG.find(item => item.name.toLowerCase().includes(lower));
+}
+
+export function getItemsByCategory(category: string): StationeryItem[] {
+  return CATALOG.filter(item => item.category === category.toLowerCase());
+}
+
+export function searchItems(query: string): StationeryItem[] {
+  const lower = query.toLowerCase();
+  return CATALOG.filter(
+    item =>
+      item.name.toLowerCase().includes(lower) ||
+      item.description.toLowerCase().includes(lower) ||
+      item.category.includes(lower)
+  );
+}

--- a/onchain-agents/coding-labs/packages/store-agent/src/executor.ts
+++ b/onchain-agents/coding-labs/packages/store-agent/src/executor.ts
@@ -1,0 +1,256 @@
+import { v4 as uuidv4 } from 'uuid';
+import type {
+  Task,
+  TaskArtifactUpdateEvent,
+  TaskStatusUpdateEvent,
+} from '@a2a-js/sdk';
+import type {
+  AgentExecutor,
+  RequestContext,
+  ExecutionEventBus,
+} from '@a2a-js/sdk/server';
+import type { WalletContext } from '@coding-labs/shared';
+import {
+  skillHandlers,
+  detectSkill,
+  extractTextFromMessage,
+} from './skills/index.js';
+
+function extractWalletContext(
+  metadata?: Record<string, unknown>
+): WalletContext | undefined {
+  if (!metadata?.wallet) return undefined;
+  const wallet = metadata.wallet as Record<string, unknown>;
+  if (
+    typeof wallet.address === 'string' &&
+    typeof wallet.chainId === 'number' &&
+    typeof wallet.connected === 'boolean'
+  ) {
+    return {
+      address: wallet.address as `0x${string}`,
+      chainId: wallet.chainId,
+      connected: wallet.connected,
+    };
+  }
+  return undefined;
+}
+
+export class StoreAgentExecutor implements AgentExecutor {
+  private cancelledTasks = new Set<string>();
+
+  public cancelTask = async (
+    taskId: string,
+    _eventBus: ExecutionEventBus
+  ): Promise<void> => {
+    console.log(`[StoreAgent] Cancellation requested for task: ${taskId}`);
+    this.cancelledTasks.add(taskId);
+  };
+
+  async execute(
+    requestContext: RequestContext,
+    eventBus: ExecutionEventBus
+  ): Promise<void> {
+    const { userMessage, task: existingTask } = requestContext;
+    const taskId = existingTask?.id || uuidv4();
+    const contextId =
+      userMessage.contextId || existingTask?.contextId || uuidv4();
+
+    console.log(
+      `[StoreAgent] Processing message ${userMessage.messageId} for task ${taskId}`
+    );
+
+    if (!existingTask) {
+      const initialTask: Task = {
+        kind: 'task',
+        id: taskId,
+        contextId: contextId,
+        status: {
+          state: 'submitted',
+          timestamp: new Date().toISOString(),
+        },
+        history: [userMessage],
+        metadata: userMessage.metadata,
+        artifacts: [],
+      };
+      eventBus.publish(initialTask);
+    }
+
+    const userText = extractTextFromMessage(userMessage);
+    const skillId = detectSkill(userText);
+    const walletContext = extractWalletContext(
+      userMessage.metadata as Record<string, unknown> | undefined
+    );
+
+    console.log(
+      `[StoreAgent] Detected skill: ${skillId}, wallet: ${walletContext?.address || 'not connected'}`
+    );
+
+    const workingUpdate: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId: taskId,
+      contextId: contextId,
+      status: {
+        state: 'working',
+        message: {
+          kind: 'message',
+          role: 'agent',
+          messageId: uuidv4(),
+          parts: [{ kind: 'text', text: `Using skill: ${skillId}...` }],
+          taskId: taskId,
+          contextId: contextId,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      final: false,
+    };
+    eventBus.publish(workingUpdate);
+
+    const handler = skillHandlers[skillId];
+    if (!handler) {
+      const errorUpdate: TaskStatusUpdateEvent = {
+        kind: 'status-update',
+        taskId: taskId,
+        contextId: contextId,
+        status: {
+          state: 'failed',
+          message: {
+            kind: 'message',
+            role: 'agent',
+            messageId: uuidv4(),
+            parts: [{ kind: 'text', text: `Skill '${skillId}' is not yet implemented.` }],
+            taskId: taskId,
+            contextId: contextId,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        final: true,
+      };
+      eventBus.publish(errorUpdate);
+      eventBus.finished();
+      return;
+    }
+
+    try {
+      const artifacts: string[] = [];
+
+      for await (const event of handler(userMessage, walletContext)) {
+        if (this.cancelledTasks.has(taskId)) {
+          console.log(`[StoreAgent] Task ${taskId} cancelled`);
+          this.cancelledTasks.delete(taskId);
+          const cancelledUpdate: TaskStatusUpdateEvent = {
+            kind: 'status-update',
+            taskId: taskId,
+            contextId: contextId,
+            status: { state: 'canceled', timestamp: new Date().toISOString() },
+            final: true,
+          };
+          eventBus.publish(cancelledUpdate);
+          eventBus.finished();
+          return;
+        }
+
+        switch (event.type) {
+          case 'status': {
+            const statusUpdate: TaskStatusUpdateEvent = {
+              kind: 'status-update',
+              taskId, contextId,
+              status: {
+                state: 'working',
+                message: {
+                  kind: 'message', role: 'agent', messageId: uuidv4(),
+                  parts: [{ kind: 'text', text: event.message }],
+                  taskId, contextId,
+                },
+                timestamp: new Date().toISOString(),
+              },
+              final: false,
+            };
+            eventBus.publish(statusUpdate);
+            break;
+          }
+          case 'artifact': {
+            artifacts.push(event.name);
+            const artifactUpdate: TaskArtifactUpdateEvent = {
+              kind: 'artifact-update',
+              taskId, contextId,
+              artifact: {
+                artifactId: event.name,
+                name: event.name,
+                parts: [{ kind: 'text', text: event.content }],
+              },
+              append: false,
+              lastChunk: true,
+            };
+            eventBus.publish(artifactUpdate);
+            break;
+          }
+          case 'error': {
+            const errorUpdate: TaskStatusUpdateEvent = {
+              kind: 'status-update',
+              taskId, contextId,
+              status: {
+                state: 'failed',
+                message: {
+                  kind: 'message', role: 'agent', messageId: uuidv4(),
+                  parts: [{ kind: 'text', text: event.message }],
+                  taskId, contextId,
+                },
+                timestamp: new Date().toISOString(),
+              },
+              final: true,
+            };
+            eventBus.publish(errorUpdate);
+            eventBus.finished();
+            return;
+          }
+          case 'result':
+            break;
+        }
+      }
+
+      const completionMessage =
+        artifacts.length > 0
+          ? `Generated: ${artifacts.join(', ')}`
+          : 'Task completed successfully.';
+
+      const finalUpdate: TaskStatusUpdateEvent = {
+        kind: 'status-update',
+        taskId, contextId,
+        status: {
+          state: 'completed',
+          message: {
+            kind: 'message', role: 'agent', messageId: uuidv4(),
+            parts: [{ kind: 'text', text: completionMessage }],
+            taskId, contextId,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        final: true,
+      };
+      eventBus.publish(finalUpdate);
+      eventBus.finished();
+
+      console.log(`[StoreAgent] Task ${taskId} completed successfully`);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      console.error(`[StoreAgent] Task ${taskId} failed:`, error);
+
+      const errorUpdate: TaskStatusUpdateEvent = {
+        kind: 'status-update',
+        taskId, contextId,
+        status: {
+          state: 'failed',
+          message: {
+            kind: 'message', role: 'agent', messageId: uuidv4(),
+            parts: [{ kind: 'text', text: `Agent error: ${errorMessage}` }],
+            taskId, contextId,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        final: true,
+      };
+      eventBus.publish(errorUpdate);
+      eventBus.finished();
+    }
+  }
+}

--- a/onchain-agents/coding-labs/packages/store-agent/src/index.ts
+++ b/onchain-agents/coding-labs/packages/store-agent/src/index.ts
@@ -1,0 +1,69 @@
+import express from 'express';
+import type { TaskStore } from '@a2a-js/sdk/server';
+import { InMemoryTaskStore, DefaultRequestHandler } from '@a2a-js/sdk/server';
+import { A2AExpressApp } from '@a2a-js/sdk/server/express';
+import { storeAgentCard } from './agent-card.js';
+import { StoreAgentExecutor } from './executor.js';
+
+let configPort = 4004;
+let configHost = 'localhost';
+try {
+  const { loadConfigFile, getServiceConfig, findConfigPath } =
+    await import('@coding-labs/shared/config');
+  const configPath = findConfigPath();
+  if (configPath) {
+    const config = loadConfigFile(configPath);
+    const serviceConfig = getServiceConfig(config, 'store-agent');
+    configPort = serviceConfig.port;
+    configHost = serviceConfig.host;
+    console.log(`[StoreAgent] Loaded config from ${configPath}`);
+  }
+} catch {
+  console.log('[StoreAgent] No config.toml found, using defaults');
+}
+
+const PORT = parseInt(
+  process.env.PORT || process.env.STORE_AGENT_PORT || String(configPort),
+  10
+);
+const HOST = process.env.HOST || process.env.STORE_AGENT_HOST || configHost;
+
+async function main() {
+  console.log('[StoreAgent] Starting Store Agent...');
+
+  const taskStore: TaskStore = new InMemoryTaskStore();
+  const agentExecutor = new StoreAgentExecutor();
+  const requestHandler = new DefaultRequestHandler(
+    storeAgentCard,
+    taskStore,
+    agentExecutor
+  );
+
+  const appBuilder = new A2AExpressApp(requestHandler);
+  const expressApp = appBuilder.setupRoutes(express(), '');
+
+  expressApp.get('/health', (_req, res) => {
+    res.json({ status: 'healthy', agent: 'store-agent', version: '0.1.0' });
+  });
+
+  expressApp.get('/.well-known/agent.json', (_req, res) => {
+    res.json(storeAgentCard);
+  });
+
+  expressApp.listen(PORT, HOST, () => {
+    console.log(`[StoreAgent] Server started on http://${HOST}:${PORT}`);
+    console.log(`[StoreAgent] Agent Card: http://localhost:${PORT}/.well-known/agent.json`);
+    console.log(`[StoreAgent] Health: http://localhost:${PORT}/health`);
+    console.log('[StoreAgent] Press Ctrl+C to stop the server');
+    console.log('');
+    console.log('[StoreAgent] Available skills:');
+    storeAgentCard.skills?.forEach((skill) => {
+      console.log(`  - ${skill.id}: ${skill.name}`);
+    });
+  });
+}
+
+main().catch((error) => {
+  console.error('[StoreAgent] Failed to start:', error);
+  process.exit(1);
+});

--- a/onchain-agents/coding-labs/packages/store-agent/src/skills/browse.ts
+++ b/onchain-agents/coding-labs/packages/store-agent/src/skills/browse.ts
@@ -1,0 +1,69 @@
+import type { Message } from '@a2a-js/sdk';
+import type { WalletContext } from '@coding-labs/shared';
+import type { SkillEvent } from './index.js';
+import { extractTextFromMessage } from './index.js';
+import { CATALOG, getItemsByCategory, searchItems } from '../catalog.js';
+
+export async function* browseCatalog(
+  userMessage: Message,
+  _walletContext?: WalletContext
+): AsyncGenerator<SkillEvent, void, unknown> {
+  yield { type: 'status', message: 'Browsing the stationery catalog...' };
+
+  const text = extractTextFromMessage(userMessage).toLowerCase();
+
+  // Check for category filter
+  const categories = ['notebooks', 'pens', 'pencils', 'erasers', 'markers', 'paper', 'accessories'];
+  let items = CATALOG;
+  let filterLabel = 'All Items';
+
+  for (const category of categories) {
+    // Match both singular and plural forms
+    const singular = category.replace(/s$/, '');
+    if (text.includes(category) || text.includes(singular)) {
+      items = getItemsByCategory(category);
+      filterLabel = `Category: ${category.charAt(0).toUpperCase() + category.slice(1)}`;
+      break;
+    }
+  }
+
+  // If no category match, check for search terms (excluding common words)
+  if (items === CATALOG && !text.includes('all') && !text.includes('everything') && !text.includes('catalog') && !text.includes('what do you')) {
+    const searchTerms = text.replace(/show|me|list|search|find|for|the|a|an|do|you|have|sell/g, '').trim();
+    if (searchTerms.length > 2) {
+      const results = searchItems(searchTerms);
+      if (results.length > 0) {
+        items = results;
+        filterLabel = `Search: "${searchTerms.trim()}"`;
+      }
+    }
+  }
+
+  // Format catalog as a readable list
+  let catalog = `## 🏪 Stationery Store — ${filterLabel}\n\n`;
+  catalog += `| # | Item | Category | Price (USDC) | Status |\n`;
+  catalog += `|---|------|----------|--------------|--------|\n`;
+
+  items.forEach((item, index) => {
+    const status = item.inStock ? '✅ In Stock' : '❌ Out of Stock';
+    catalog += `| ${index + 1} | **${item.name}** | ${item.category} | $${item.priceUSDC} | ${status} |\n`;
+  });
+
+  catalog += `\n_${items.length} item(s) found. Say "tell me about [item name]" for details, or "buy [item name]" to purchase._`;
+
+  yield {
+    type: 'artifact',
+    name: 'catalog.md',
+    content: catalog,
+    mimeType: 'text/markdown',
+  };
+
+  yield {
+    type: 'result',
+    data: {
+      itemCount: items.length,
+      filter: filterLabel,
+      items: items.map(i => ({ id: i.id, name: i.name, priceUSDC: i.priceUSDC })),
+    },
+  };
+}

--- a/onchain-agents/coding-labs/packages/store-agent/src/skills/confirm.ts
+++ b/onchain-agents/coding-labs/packages/store-agent/src/skills/confirm.ts
@@ -1,0 +1,89 @@
+import type { Message } from '@a2a-js/sdk';
+import type { WalletContext } from '@coding-labs/shared';
+import type { SkillEvent } from './index.js';
+import { extractTextFromMessage } from './index.js';
+import { getOrder, updateOrderStatus } from './purchase.js';
+
+export async function* confirmPurchase(
+  userMessage: Message,
+  _walletContext?: WalletContext
+): AsyncGenerator<SkillEvent, void, unknown> {
+  yield { type: 'status', message: 'Verifying your purchase...' };
+
+  const text = extractTextFromMessage(userMessage);
+
+  // Extract order ID
+  const orderMatch = text.match(/ord_[a-z0-9]+/i);
+  const orderId = orderMatch?.[0];
+
+  // Extract transaction hash
+  const txMatch = text.match(/0x[a-fA-F0-9]{64}/);
+  const txHash = txMatch?.[0];
+
+  if (!orderId) {
+    yield {
+      type: 'error',
+      message: 'Please provide your order ID (e.g., "confirm order ord_abc12345 with tx 0x...").',
+    };
+    return;
+  }
+
+  const order = getOrder(orderId);
+  if (!order) {
+    yield {
+      type: 'error',
+      message: `Order \`${orderId}\` not found. Please check the order ID and try again.`,
+    };
+    return;
+  }
+
+  if (order.status === 'confirmed') {
+    yield {
+      type: 'artifact',
+      name: 'confirmation.md',
+      content: `## ✅ Order Already Confirmed\n\n**Order ID:** \`${orderId}\`\n**Item:** ${order.itemName}\n**Status:** Confirmed`,
+      mimeType: 'text/markdown',
+    };
+    yield { type: 'result', data: { orderId, status: 'already_confirmed' } };
+    return;
+  }
+
+  if (!txHash) {
+    yield {
+      type: 'error',
+      message: `Order \`${orderId}\` found (${order.itemName}, $${order.priceUSDC} USDC) but no transaction hash provided. Please include your payment transaction hash: "confirm order ${orderId} with tx 0x..."`,
+    };
+    return;
+  }
+
+  // In a real implementation, we would verify the transaction on-chain
+  // For this mock, we accept any valid-looking tx hash
+  updateOrderStatus(orderId, 'confirmed');
+
+  const confirmation = `## ✅ Purchase Confirmed!\n\n` +
+    `**Order ID:** \`${orderId}\`\n` +
+    `**Item:** ${order.itemName}\n` +
+    `**Amount Paid:** $${order.priceUSDC} USDC\n` +
+    `**Transaction:** \`${txHash}\`\n` +
+    `**Status:** ✅ Confirmed\n` +
+    `**Confirmed At:** ${new Date().toISOString()}\n\n` +
+    `Thank you for your purchase! 🎉`;
+
+  yield {
+    type: 'artifact',
+    name: 'confirmation.md',
+    content: confirmation,
+    mimeType: 'text/markdown',
+  };
+
+  yield {
+    type: 'result',
+    data: {
+      orderId,
+      item: order.itemName,
+      amountUSDC: order.priceUSDC,
+      txHash,
+      status: 'confirmed',
+    },
+  };
+}

--- a/onchain-agents/coding-labs/packages/store-agent/src/skills/index.ts
+++ b/onchain-agents/coding-labs/packages/store-agent/src/skills/index.ts
@@ -1,0 +1,101 @@
+import type { Message } from '@a2a-js/sdk';
+import type { WalletContext } from '@coding-labs/shared';
+import { browseCatalog } from './browse.js';
+import { getItemDetail } from './item-detail.js';
+import { purchaseItem } from './purchase.js';
+import { confirmPurchase } from './confirm.js';
+
+/**
+ * Skill handler function type
+ */
+export type SkillHandler = (
+  userMessage: Message,
+  walletContext?: WalletContext
+) => AsyncGenerator<SkillEvent, void, unknown>;
+
+/**
+ * Skill event types emitted during execution
+ */
+export type SkillEvent =
+  | { type: 'status'; message: string }
+  | { type: 'artifact'; name: string; content: string; mimeType?: string }
+  | { type: 'result'; data: unknown }
+  | { type: 'error'; message: string };
+
+/**
+ * Extract text content from a message
+ */
+export function extractTextFromMessage(message: Message): string {
+  return message.parts
+    .filter((p) => {
+      const part = p as { kind?: string; type?: string };
+      return part.kind === 'text' || part.type === 'text';
+    })
+    .map((p) => {
+      const part = p as { text?: string };
+      return part.text ?? '';
+    })
+    .join('\n');
+}
+
+/**
+ * Skill registry mapping skill IDs to handlers
+ */
+export const skillHandlers: Record<string, SkillHandler> = {
+  'browse': browseCatalog,
+  'item-detail': getItemDetail,
+  'purchase': purchaseItem,
+  'confirm': confirmPurchase,
+};
+
+/**
+ * Detect which skill to use based on user message.
+ *
+ * Priority order:
+ *   1. Purchase (buy/order intent)
+ *   2. Confirm (payment confirmation)
+ *   3. Item detail (specific item query)
+ *   4. Browse (default - catalog browsing)
+ */
+export function detectSkill(userMessage: string): string {
+  const text = userMessage.toLowerCase();
+
+  // 1. Confirm - check first since it's very specific
+  if (
+    text.includes('confirm') ||
+    text.includes('verify payment') ||
+    text.includes('receipt') ||
+    (text.includes('order') && text.includes('status'))
+  ) {
+    return 'confirm';
+  }
+
+  // 2. Purchase
+  if (
+    text.includes('buy') ||
+    text.includes('purchase') ||
+    text.includes('order') ||
+    text.includes('i want') ||
+    text.includes('i\'d like') ||
+    text.includes('add to cart') ||
+    text.includes('checkout')
+  ) {
+    return 'purchase';
+  }
+
+  // 3. Item detail - specific item inquiry
+  if (
+    text.includes('detail') ||
+    text.includes('tell me about') ||
+    text.includes('how much') ||
+    text.includes('price of') ||
+    text.includes('info on') ||
+    text.includes('information about') ||
+    text.includes('describe')
+  ) {
+    return 'item-detail';
+  }
+
+  // 4. Default to browse
+  return 'browse';
+}

--- a/onchain-agents/coding-labs/packages/store-agent/src/skills/item-detail.ts
+++ b/onchain-agents/coding-labs/packages/store-agent/src/skills/item-detail.ts
@@ -1,0 +1,68 @@
+import type { Message } from '@a2a-js/sdk';
+import type { WalletContext } from '@coding-labs/shared';
+import type { SkillEvent } from './index.js';
+import { extractTextFromMessage } from './index.js';
+import { findItemByName, findItemById, CATALOG } from '../catalog.js';
+
+export async function* getItemDetail(
+  userMessage: Message,
+  _walletContext?: WalletContext
+): AsyncGenerator<SkillEvent, void, unknown> {
+  yield { type: 'status', message: 'Looking up item details...' };
+
+  const text = extractTextFromMessage(userMessage);
+
+  // Try to find the item by name or ID
+  let item = findItemByName(text);
+  if (!item) {
+    // Try to extract item name from common patterns
+    const patterns = [
+      /(?:tell me about|details? (?:on|for|about)|info (?:on|about)|describe|how much (?:is|does|for)) (?:the |a )?(.+)/i,
+      /(?:price of|cost of) (?:the |a )?(.+)/i,
+    ];
+
+    for (const pattern of patterns) {
+      const match = text.match(pattern);
+      if (match) {
+        item = findItemByName(match[1].trim());
+        if (item) break;
+        item = findItemById(match[1].trim());
+        if (item) break;
+      }
+    }
+  }
+
+  if (!item) {
+    // Try matching against all items
+    const lower = text.toLowerCase();
+    item = CATALOG.find(i => lower.includes(i.name.toLowerCase()));
+  }
+
+  if (!item) {
+    yield {
+      type: 'error',
+      message: `Could not find that item. Try browsing the catalog first with "show me all items" to see available products.`,
+    };
+    return;
+  }
+
+  const detail = `## ${item.name}\n\n` +
+    `**ID:** \`${item.id}\`\n` +
+    `**Category:** ${item.category}\n` +
+    `**Price:** $${item.priceUSDC} USDC\n` +
+    `**Status:** ${item.inStock ? '✅ In Stock' : '❌ Out of Stock'}\n\n` +
+    `${item.description}\n\n` +
+    `_To purchase, say "buy ${item.name}"_`;
+
+  yield {
+    type: 'artifact',
+    name: 'item-detail.md',
+    content: detail,
+    mimeType: 'text/markdown',
+  };
+
+  yield {
+    type: 'result',
+    data: { item },
+  };
+}

--- a/onchain-agents/coding-labs/packages/store-agent/src/skills/purchase.ts
+++ b/onchain-agents/coding-labs/packages/store-agent/src/skills/purchase.ts
@@ -1,0 +1,143 @@
+import { v4 as uuidv4 } from 'uuid';
+import type { Message } from '@a2a-js/sdk';
+import type { WalletContext } from '@coding-labs/shared';
+import type { SkillEvent } from './index.js';
+import { extractTextFromMessage } from './index.js';
+import { findItemByName, findItemById, CATALOG } from '../catalog.js';
+
+// x402 payment configuration defaults
+// These can be overridden via config.toml / environment variables
+const X402_NETWORK = process.env.X402_DEFAULT_NETWORK || 'eip155:84532'; // Base Sepolia
+const STORE_WALLET = process.env.X402_STORE_WALLET || '0x0000000000000000000000000000000000000000';
+
+// USDC contract addresses per network
+const USDC_ADDRESSES: Record<string, string> = {
+  'eip155:84532': '0x036CbD53842c5426634e7929541eC2318f3dCF7e',  // Base Sepolia
+  'eip155:8453': '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',   // Base Mainnet
+  'eip155:1': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',      // Ethereum Mainnet
+};
+
+// Simple in-memory order store
+const orders = new Map<string, { itemId: string; itemName: string; priceUSDC: string; priceRaw: string; status: string; createdAt: string }>();
+
+export function getOrder(orderId: string) {
+  return orders.get(orderId);
+}
+
+export function updateOrderStatus(orderId: string, status: string) {
+  const order = orders.get(orderId);
+  if (order) {
+    order.status = status;
+  }
+}
+
+export async function* purchaseItem(
+  userMessage: Message,
+  walletContext?: WalletContext
+): AsyncGenerator<SkillEvent, void, unknown> {
+  yield { type: 'status', message: 'Processing your purchase request...' };
+
+  const text = extractTextFromMessage(userMessage);
+
+  // Find the item
+  let item = findItemByName(text);
+  if (!item) {
+    const patterns = [
+      /(?:buy|purchase|order|i want|i'd like) (?:the |a |an )?(.+)/i,
+      /(?:add) (?:the |a |an )?(.+?)(?:\s+to cart)?$/i,
+    ];
+
+    for (const pattern of patterns) {
+      const match = text.match(pattern);
+      if (match) {
+        item = findItemByName(match[1].trim());
+        if (item) break;
+        item = findItemById(match[1].trim());
+        if (item) break;
+      }
+    }
+  }
+
+  if (!item) {
+    const lower = text.toLowerCase();
+    item = CATALOG.find(i => lower.includes(i.name.toLowerCase()));
+  }
+
+  if (!item) {
+    yield {
+      type: 'error',
+      message: 'Could not find that item. Please browse the catalog first with "show me all items" and then say "buy [item name]".',
+    };
+    return;
+  }
+
+  if (!item.inStock) {
+    yield {
+      type: 'error',
+      message: `Sorry, **${item.name}** is currently out of stock.`,
+    };
+    return;
+  }
+
+  // Create order
+  const orderId = `ord_${uuidv4().slice(0, 8)}`;
+  orders.set(orderId, {
+    itemId: item.id,
+    itemName: item.name,
+    priceUSDC: item.priceUSDC,
+    priceRaw: item.priceRaw,
+    status: 'pending_payment',
+    createdAt: new Date().toISOString(),
+  });
+
+  const usdcAddress = USDC_ADDRESSES[X402_NETWORK] || USDC_ADDRESSES['eip155:84532'];
+
+  // Build x402 PaymentRequired response
+  const paymentRequired = {
+    accepts: [
+      {
+        scheme: 'exact',
+        network: X402_NETWORK,
+        price: `$${item.priceUSDC}`,
+        payTo: STORE_WALLET,
+        asset: usdcAddress,
+      },
+    ],
+    description: `Purchase: ${item.name}`,
+    mimeType: 'application/json',
+  };
+
+  const orderSummary = `## 🛒 Order Created\n\n` +
+    `**Order ID:** \`${orderId}\`\n` +
+    `**Item:** ${item.name}\n` +
+    `**Price:** $${item.priceUSDC} USDC\n` +
+    `**Status:** ⏳ Pending Payment\n\n` +
+    `### Payment Details (x402)\n\n` +
+    `- **Network:** ${X402_NETWORK}\n` +
+    `- **Scheme:** exact\n` +
+    `- **Pay To:** \`${STORE_WALLET}\`\n` +
+    `- **Asset (USDC):** \`${usdcAddress}\`\n` +
+    `- **Amount:** ${item.priceRaw} (${item.priceUSDC} USDC)\n\n` +
+    (walletContext?.connected
+      ? `✅ Wallet connected: \`${walletContext.address}\`\n\n`
+      : `⚠️ Please connect your wallet to proceed with payment.\n\n`) +
+    `_To complete payment, tell the **@payment** agent: "pay for order ${orderId}"_\n` +
+    `_After payment, come back and say: "confirm order ${orderId} with tx 0x..."_`;
+
+  yield {
+    type: 'artifact',
+    name: 'order.md',
+    content: orderSummary,
+    mimeType: 'text/markdown',
+  };
+
+  yield {
+    type: 'result',
+    data: {
+      orderId,
+      item: { id: item.id, name: item.name, priceUSDC: item.priceUSDC },
+      paymentRequired,
+      status: 'pending_payment',
+    },
+  };
+}

--- a/onchain-agents/coding-labs/packages/store-agent/tsconfig.json
+++ b/onchain-agents/coding-labs/packages/store-agent/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/onchain-agents/coding-labs/scripts/common.sh
+++ b/onchain-agents/coding-labs/scripts/common.sh
@@ -25,6 +25,10 @@ readonly SOMNIA_AGENT_PORT="${SOMNIA_AGENT_PORT:-4001}"
 readonly SOMNIA_AGENT_HOST="${SOMNIA_AGENT_HOST:-localhost}"
 readonly MIDNIGHT_AGENT_PORT="${MIDNIGHT_AGENT_PORT:-4003}"
 readonly MIDNIGHT_AGENT_HOST="${MIDNIGHT_AGENT_HOST:-localhost}"
+readonly STORE_AGENT_PORT="${STORE_AGENT_PORT:-4004}"
+readonly STORE_AGENT_HOST="${STORE_AGENT_HOST:-localhost}"
+readonly PAYMENT_AGENT_PORT="${PAYMENT_AGENT_PORT:-4005}"
+readonly PAYMENT_AGENT_HOST="${PAYMENT_AGENT_HOST:-localhost}"
 
 # Default agent (for scripts that target a single agent)
 readonly DEFAULT_AGENT="${AGENT:-somnia}"
@@ -117,6 +121,12 @@ get_agent_url() {
     midnight)
       echo "http://${MIDNIGHT_AGENT_HOST}:${MIDNIGHT_AGENT_PORT}"
       ;;
+    store)
+      echo "http://${STORE_AGENT_HOST}:${STORE_AGENT_PORT}"
+      ;;
+    payment)
+      echo "http://${PAYMENT_AGENT_HOST}:${PAYMENT_AGENT_PORT}"
+      ;;
     *)
       log_warn "Unknown agent: $agent_id, falling back to somnia"
       echo "http://${SOMNIA_AGENT_HOST}:${SOMNIA_AGENT_PORT}"
@@ -130,6 +140,8 @@ list_agents() {
     log_warn "Could not reach registry, using static agent list"
     echo "somnia: http://${SOMNIA_AGENT_HOST}:${SOMNIA_AGENT_PORT}"
     echo "midnight: http://${MIDNIGHT_AGENT_HOST}:${MIDNIGHT_AGENT_PORT}"
+    echo "store: http://${STORE_AGENT_HOST}:${STORE_AGENT_PORT}"
+    echo "payment: http://${PAYMENT_AGENT_HOST}:${PAYMENT_AGENT_PORT}"
   }
 }
 

--- a/onchain-agents/coding-labs/scripts/dev.sh
+++ b/onchain-agents/coding-labs/scripts/dev.sh
@@ -16,6 +16,8 @@ cmd_build() {
   run_pnpm --filter @coding-labs/somnia-agent build
   run_pnpm --filter @coding-labs/midnight-agent build
   run_pnpm --filter @coding-labs/midnight-mcp build
+  run_pnpm --filter @coding-labs/store-agent build
+  run_pnpm --filter @coding-labs/payment-agent build
   log_success "Build complete"
 }
 
@@ -33,6 +35,8 @@ cmd_run_all() {
   log_info "  - Agent Registry:    http://localhost:4000"
   log_info "  - Somnia Agent:      http://localhost:4001"
   log_info "  - Midnight Agent:    http://localhost:4003"
+  log_info "  - Store Agent:       http://localhost:4004"
+  log_info "  - Payment Agent:     http://localhost:4005"
   log_info "  - Midnight MCP:      http://localhost:4010"
   log_info "  - OpenCode Backend:  http://localhost:4097 (API)"
   log_info "  - OpenCode Frontend: http://localhost:3000 (Vite dev server)"
@@ -42,13 +46,15 @@ cmd_run_all() {
   echo ""
   
   npx concurrently \
-    --names "registry,somnia,midnight,mcp,backend,frontend" \
-    --prefix-colors "blue,green,magenta,red,yellow,cyan" \
+    --names "registry,somnia,midnight,store,payment,mcp,backend,frontend" \
+    --prefix-colors "blue,green,magenta,white,red.bold,red,yellow,cyan" \
     --prefix "[{name}]" \
     --kill-others-on-fail \
     "cd packages/agent-registry && npx tsx src/index.ts" \
     "cd packages/somnia-agent && npx tsx src/index.ts" \
     "cd packages/midnight-agent && npx tsx src/index.ts" \
+    "cd packages/store-agent && npx tsx src/index.ts" \
+    "cd packages/payment-agent && npx tsx src/index.ts" \
     "cd packages/midnight-mcp && npx tsx src/index.ts" \
     "cd opencode && bun run dev -- web --hostname 0.0.0.0 --port 4097" \
     "cd opencode/packages/app && bun run dev"
@@ -66,6 +72,8 @@ cmd_run_all_built() {
   log_info "  - Agent Registry:  http://localhost:4000"
   log_info "  - Somnia Agent:    http://localhost:4001"
   log_info "  - Midnight Agent:  http://localhost:4003"
+  log_info "  - Store Agent:     http://localhost:4004"
+  log_info "  - Payment Agent:   http://localhost:4005"
   log_info "  - OpenCode Web:    http://localhost:4097 (backend + static frontend)"
   log_info ""
   log_info "Access the app at: http://localhost:4097"
@@ -75,13 +83,15 @@ cmd_run_all_built() {
   export OPENCODE_STATIC_DIR="$(pwd)/opencode/packages/app/dist"
   
   npx concurrently \
-    --names "registry,somnia,midnight,opencode" \
-    --prefix-colors "blue,green,magenta,yellow" \
+    --names "registry,somnia,midnight,store,payment,opencode" \
+    --prefix-colors "blue,green,magenta,white,red.bold,yellow" \
     --prefix "[{name}]" \
     --kill-others-on-fail \
     "cd packages/agent-registry && npx tsx src/index.ts" \
     "cd packages/somnia-agent && npx tsx src/index.ts" \
     "cd packages/midnight-agent && npx tsx src/index.ts" \
+    "cd packages/store-agent && npx tsx src/index.ts" \
+    "cd packages/payment-agent && npx tsx src/index.ts" \
     "cd opencode && bun run dev -- web --hostname 0.0.0.0 --port 4097"
 }
 
@@ -91,6 +101,8 @@ cmd_run_all_with_login() {
   log_info "  - Agent Registry:    http://localhost:4000"
   log_info "  - Somnia Agent:      http://localhost:4001"
   log_info "  - Midnight Agent:    http://localhost:4003"
+  log_info "  - Store Agent:       http://localhost:4004"
+  log_info "  - Payment Agent:     http://localhost:4005"
   log_info "  - Login Page:        http://localhost:4098"
   log_info "  - OpenCode Backend:  http://localhost:4097 (API)"
   log_info "  - OpenCode Frontend: http://localhost:3000 (Vite dev server)"
@@ -101,13 +113,15 @@ cmd_run_all_with_login() {
   echo ""
   
   npx concurrently \
-    --names "registry,somnia,midnight,login,backend,frontend" \
-    --prefix-colors "blue,green,magenta,cyan,yellow,white" \
+    --names "registry,somnia,midnight,store,payment,login,backend,frontend" \
+    --prefix-colors "blue,green,magenta,white,red.bold,cyan,yellow,gray" \
     --prefix "[{name}]" \
     --kill-others-on-fail \
     "cd packages/agent-registry && npx tsx src/index.ts" \
     "cd packages/somnia-agent && npx tsx src/index.ts" \
     "cd packages/midnight-agent && npx tsx src/index.ts" \
+    "cd packages/store-agent && npx tsx src/index.ts" \
+    "cd packages/payment-agent && npx tsx src/index.ts" \
     "cd packages/opencode-login && APP_URL=http://localhost:3000 node server.js" \
     "cd opencode && bun run dev -- web --hostname 0.0.0.0 --port 4097" \
     "cd opencode/packages/app && bun run dev"
@@ -125,6 +139,8 @@ cmd_run_all_with_login_built() {
   log_info "  - Agent Registry:  http://localhost:4000"
   log_info "  - Somnia Agent:    http://localhost:4001"
   log_info "  - Midnight Agent:  http://localhost:4003"
+  log_info "  - Store Agent:     http://localhost:4004"
+  log_info "  - Payment Agent:   http://localhost:4005"
   log_info "  - Login Page:      http://localhost:4098"
   log_info "  - OpenCode Web:    http://localhost:4097 (backend + static frontend)"
   log_info ""
@@ -136,13 +152,15 @@ cmd_run_all_with_login_built() {
   export OPENCODE_STATIC_DIR="$(pwd)/opencode/packages/app/dist"
   
   npx concurrently \
-    --names "registry,somnia,midnight,login,opencode" \
-    --prefix-colors "blue,green,magenta,cyan,yellow" \
+    --names "registry,somnia,midnight,store,payment,login,opencode" \
+    --prefix-colors "blue,green,magenta,white,red.bold,cyan,yellow" \
     --prefix "[{name}]" \
     --kill-others-on-fail \
     "cd packages/agent-registry && npx tsx src/index.ts" \
     "cd packages/somnia-agent && npx tsx src/index.ts" \
     "cd packages/midnight-agent && npx tsx src/index.ts" \
+    "cd packages/store-agent && npx tsx src/index.ts" \
+    "cd packages/payment-agent && npx tsx src/index.ts" \
     "cd packages/opencode-login && APP_URL=http://localhost:4097 node server.js" \
     "cd opencode && bun run dev -- web --hostname 0.0.0.0 --port 4097"
 }
@@ -153,6 +171,8 @@ cmd_typecheck() {
   run_pnpm --filter @coding-labs/somnia-agent typecheck
   run_pnpm --filter @coding-labs/midnight-agent typecheck
   run_pnpm --filter @coding-labs/midnight-mcp typecheck
+  run_pnpm --filter @coding-labs/store-agent typecheck
+  run_pnpm --filter @coding-labs/payment-agent typecheck
   log_success "Type checking passed"
 }
 
@@ -180,6 +200,8 @@ cmd_clean() {
   rm -rf packages/somnia-agent/dist
   rm -rf packages/midnight-agent/dist
   rm -rf packages/midnight-mcp/dist
+  rm -rf packages/store-agent/dist
+  rm -rf packages/payment-agent/dist
   rm -rf node_modules/.cache
   log_success "Clean complete"
 }
@@ -192,6 +214,8 @@ cmd_clean_all() {
   rm -rf packages/somnia-agent/node_modules
   rm -rf packages/midnight-agent/node_modules
   rm -rf packages/midnight-mcp/node_modules
+  rm -rf packages/store-agent/node_modules
+  rm -rf packages/payment-agent/node_modules
   log_success "Full clean complete"
 }
 


### PR DESCRIPTION
## Summary
- Add new `store-agent` A2A package (`packages/store-agent/`) — a mock stationery web store with 12 catalog items
- Add shared x402 payment protocol types (`packages/shared/src/x402/`)
- Register both store-agent and payment-agent in infrastructure (config.toml, compose.yaml, scripts)

## What's New

### Store Agent (port 4004)
A conversational A2A agent for a mock stationery store. Users can:
- **Browse** the catalog by category or search
- **View item details** with prices in USDC
- **Purchase items** — returns x402 `PaymentRequired` info
- **Confirm orders** after payment with a transaction hash

### Shared x402 Types
- `PaymentOption`, `PaymentRequired`, `OrderInfo`, `PaymentResult` interfaces
- Exported via `@coding-labs/shared/x402` subpath

### Infrastructure
- Services registered in `config.toml` (ports 4004, 4005)
- Container definitions in `compose.yaml`
- Build/run/typecheck scripts updated in `scripts/dev.sh` and `scripts/common.sh`
- x402 config section added to `config.toml` (facilitator URL, USDC addresses, networks)

## Testing
- `pnpm --filter @coding-labs/store-agent build` ✅
- `pnpm --filter @coding-labs/store-agent typecheck` ✅
- `pnpm --filter @coding-labs/shared build` ✅ (with x402 types)

Closes #3