### PR TITLE
feat: add x402 payment facilitator agent (A2A + facilitator endpoints)

### DIFF
--- a/onchain-agents/coding-labs/packages/payment-agent/Containerfile
+++ b/onchain-agents/coding-labs/packages/payment-agent/Containerfile
@@ -1,0 +1,39 @@
+# Build stage
+FROM node:22-slim AS builder
+WORKDIR /app
+
+RUN npm install -g pnpm@9
+
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY tsconfig.base.json ./
+COPY packages/shared/package.json packages/shared/
+COPY packages/payment-agent/package.json packages/payment-agent/
+
+RUN pnpm install --frozen-lockfile
+
+COPY packages/shared packages/shared
+COPY packages/payment-agent packages/payment-agent
+COPY config.toml ./
+
+RUN pnpm --filter @coding-labs/shared build
+RUN pnpm --filter @coding-labs/payment-agent build
+
+# Runtime stage
+FROM node:22-slim
+WORKDIR /app
+
+COPY --from=builder /app/packages/payment-agent/dist ./dist
+COPY --from=builder /app/packages/payment-agent/package.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages/shared/dist ./node_modules/@coding-labs/shared/dist
+COPY --from=builder /app/packages/shared/package.json ./node_modules/@coding-labs/shared/
+
+COPY packages/payment-agent/SKILLS.md ./SKILLS.md
+
+ENV NODE_ENV=production
+EXPOSE 4005
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:4005/health || exit 1
+
+CMD ["node", "dist/index.js"]

--- a/onchain-agents/coding-labs/packages/payment-agent/SKILLS.md
+++ b/onchain-agents/coding-labs/packages/payment-agent/SKILLS.md
@@ -1,0 +1,47 @@
+# Payment Agent Skills Reference
+
+This document describes the Payment Agent's capabilities for x402 protocol-based payments.
+
+## Overview
+
+The Payment Agent handles crypto payments using the x402 protocol. It serves dual roles:
+1. **Facilitator**: HTTP endpoints for payment verification and settlement
+2. **Buyer-side agent**: Conversational A2A skills for handling payments on behalf of users
+
+## Skills
+
+### pay
+Execute a payment for a store order. Reads x402 PaymentRequired details, creates an EIP-3009
+transferWithAuthorization signature request, and submits to the facilitator for settlement.
+
+### verify-payment
+Verify payment details without settling. Checks:
+- Network is supported
+- Payment scheme is supported
+- PayTo address is valid
+- Price is non-zero
+- Wallet is connected
+
+### payment-status
+Check the status of a specific payment or view all payment history.
+
+### supported
+List supported blockchain networks, payment schemes, and facilitator configuration.
+
+## x402 Protocol
+
+The x402 protocol uses HTTP 402 Payment Required to enable programmatic payments:
+1. Client requests resource → Server returns 402 with PaymentRequired
+2. Client signs payment authorization (EIP-3009 transferWithAuthorization)
+3. Client retries with PAYMENT-SIGNATURE header
+4. Server verifies via facilitator → settles payment → returns resource
+
+## Supported Networks
+- Base Sepolia (eip155:84532) — Testnet, via x402.org facilitator
+- Base Mainnet (eip155:8453) — Production, via x402.org facilitator
+- Ethereum Mainnet (eip155:1) — Production, via Primev facilitator (preconfirmations)
+
+## Facilitator Endpoints
+- POST /x402/verify — Verify payment payload
+- POST /x402/settle — Settle payment on-chain
+- GET /x402/supported — List supported networks and schemes

--- a/onchain-agents/coding-labs/packages/payment-agent/package.json
+++ b/onchain-agents/coding-labs/packages/payment-agent/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@coding-labs/payment-agent",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "pnpm exec tsc",
+    "start": "node dist/index.js",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm exec tsc --noEmit"
+  },
+  "dependencies": {
+    "@a2a-js/sdk": "^0.3.10",
+    "@coding-labs/shared": "workspace:*",
+    "express": "^4.21.0",
+    "uuid": "^11.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.13.0",
+    "@types/uuid": "^10.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/onchain-agents/coding-labs/packages/payment-agent/src/agent-card.ts
+++ b/onchain-agents/coding-labs/packages/payment-agent/src/agent-card.ts
@@ -1,0 +1,83 @@
+import type { AgentCard } from '@a2a-js/sdk';
+
+const PORT = process.env.PAYMENT_AGENT_PORT || 4005;
+const HOST = process.env.PAYMENT_AGENT_HOST || 'localhost';
+
+export const paymentAgentCard: AgentCard = {
+  name: 'Payment Agent',
+  description:
+    'x402 payment facilitator and buyer-side agent. Handles USDC payments, verification, and settlement for purchases using the x402 protocol. Supports Base Sepolia (testnet), Base Mainnet, and Ethereum Mainnet.',
+  url: `http://${HOST}:${PORT}/`,
+  protocolVersion: '0.3.0',
+  provider: {
+    organization: 'Coding Labs',
+    url: 'https://github.com/dcentral-labs/onchain-agents',
+  },
+  version: '0.1.0',
+  capabilities: {
+    streaming: true,
+    pushNotifications: false,
+    stateTransitionHistory: true,
+  },
+  defaultInputModes: ['text'],
+  defaultOutputModes: ['text'],
+  skills: [
+    {
+      id: 'pay',
+      name: 'Pay for Order',
+      description:
+        'Execute a payment for a store order using the x402 protocol. Handles wallet signing and facilitator settlement.',
+      tags: ['payment', 'x402', 'usdc', 'settle', 'buy'],
+      examples: [
+        'Pay for order ord_abc12345',
+        'Complete payment for my notebook purchase',
+        'Send USDC payment to the store',
+      ],
+      inputModes: ['text'],
+      outputModes: ['text'],
+    },
+    {
+      id: 'verify-payment',
+      name: 'Verify Payment',
+      description:
+        'Verify a payment payload without settling. Checks network support, address validity, and wallet readiness.',
+      tags: ['payment', 'verify', 'validate', 'check'],
+      examples: [
+        'Can I pay for this order?',
+        'Verify payment details for ord_abc12345',
+        'Check if this payment will work',
+      ],
+      inputModes: ['text'],
+      outputModes: ['text'],
+    },
+    {
+      id: 'payment-status',
+      name: 'Payment Status',
+      description:
+        'Check the status of a payment or view payment history.',
+      tags: ['payment', 'status', 'history', 'receipt'],
+      examples: [
+        'Check payment status for pay_abc123',
+        'Show my payment history',
+        'What payments have I made?',
+      ],
+      inputModes: ['text'],
+      outputModes: ['text'],
+    },
+    {
+      id: 'supported',
+      name: 'Supported Networks',
+      description:
+        'List supported blockchain networks, payment schemes, and facilitator information.',
+      tags: ['networks', 'supported', 'info', 'help'],
+      examples: [
+        'What networks do you support?',
+        'Which blockchains can I pay on?',
+        'Show supported payment methods',
+      ],
+      inputModes: ['text'],
+      outputModes: ['text'],
+    },
+  ],
+  supportsAuthenticatedExtendedCard: false,
+};

--- a/onchain-agents/coding-labs/packages/payment-agent/src/executor.ts
+++ b/onchain-agents/coding-labs/packages/payment-agent/src/executor.ts
@@ -1,0 +1,316 @@
+import { v4 as uuidv4 } from 'uuid';
+import type {
+  Task,
+  TaskArtifactUpdateEvent,
+  TaskStatusUpdateEvent,
+} from '@a2a-js/sdk';
+import type {
+  AgentExecutor,
+  RequestContext,
+  ExecutionEventBus,
+} from '@a2a-js/sdk/server';
+import type { WalletContext } from '@coding-labs/shared';
+import {
+  skillHandlers,
+  detectSkill,
+  extractTextFromMessage,
+} from './skills/index.js';
+
+/**
+ * Extract wallet context from message metadata
+ */
+function extractWalletContext(
+  metadata?: Record<string, unknown>
+): WalletContext | undefined {
+  if (!metadata?.wallet) return undefined;
+
+  const wallet = metadata.wallet as Record<string, unknown>;
+  if (
+    typeof wallet.address === 'string' &&
+    typeof wallet.chainId === 'number' &&
+    typeof wallet.connected === 'boolean'
+  ) {
+    return {
+      address: wallet.address as `0x${string}`,
+      chainId: wallet.chainId,
+      connected: wallet.connected,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Payment Agent Executor
+ *
+ * Handles incoming A2A messages and routes them to appropriate skill handlers.
+ */
+export class PaymentAgentExecutor implements AgentExecutor {
+  private cancelledTasks = new Set<string>();
+
+  /**
+   * Handle task cancellation requests
+   */
+  public cancelTask = async (
+    taskId: string,
+    _eventBus: ExecutionEventBus
+  ): Promise<void> => {
+    console.log(`[PaymentAgent] Cancellation requested for task: ${taskId}`);
+    this.cancelledTasks.add(taskId);
+  };
+
+  /**
+   * Execute the agent logic for a given request
+   */
+  async execute(
+    requestContext: RequestContext,
+    eventBus: ExecutionEventBus
+  ): Promise<void> {
+    const { userMessage, task: existingTask } = requestContext;
+    const taskId = existingTask?.id || uuidv4();
+    const contextId =
+      userMessage.contextId || existingTask?.contextId || uuidv4();
+
+    console.log(
+      `[PaymentAgent] Processing message ${userMessage.messageId} for task ${taskId}`
+    );
+
+    // 1. Publish initial Task if new
+    if (!existingTask) {
+      const initialTask: Task = {
+        kind: 'task',
+        id: taskId,
+        contextId: contextId,
+        status: {
+          state: 'submitted',
+          timestamp: new Date().toISOString(),
+        },
+        history: [userMessage],
+        metadata: userMessage.metadata,
+        artifacts: [],
+      };
+      eventBus.publish(initialTask);
+    }
+
+    // 2. Extract user text and detect skill
+    const userText = extractTextFromMessage(userMessage);
+    const skillId = detectSkill(userText);
+    const walletContext = extractWalletContext(
+      userMessage.metadata as Record<string, unknown> | undefined
+    );
+
+    console.log(
+      `[PaymentAgent] Detected skill: ${skillId}, wallet: ${walletContext?.address || 'not connected'}`
+    );
+
+    // 3. Publish "working" status
+    const workingUpdate: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId: taskId,
+      contextId: contextId,
+      status: {
+        state: 'working',
+        message: {
+          kind: 'message',
+          role: 'agent',
+          messageId: uuidv4(),
+          parts: [
+            {
+              kind: 'text',
+              text: `Using skill: ${skillId}...`,
+            },
+          ],
+          taskId: taskId,
+          contextId: contextId,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      final: false,
+    };
+    eventBus.publish(workingUpdate);
+
+    // 4. Get skill handler
+    const handler = skillHandlers[skillId];
+    if (!handler) {
+      // Skill not implemented yet
+      const errorUpdate: TaskStatusUpdateEvent = {
+        kind: 'status-update',
+        taskId: taskId,
+        contextId: contextId,
+        status: {
+          state: 'failed',
+          message: {
+            kind: 'message',
+            role: 'agent',
+            messageId: uuidv4(),
+            parts: [
+              {
+                kind: 'text',
+                text: `Skill '${skillId}' is not yet implemented.`,
+              },
+            ],
+            taskId: taskId,
+            contextId: contextId,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        final: true,
+      };
+      eventBus.publish(errorUpdate);
+      eventBus.finished();
+      return;
+    }
+
+    // 5. Execute skill and stream events
+    try {
+      const artifacts: string[] = [];
+
+      for await (const event of handler(userMessage, walletContext)) {
+        // Check for cancellation
+        if (this.cancelledTasks.has(taskId)) {
+          console.log(`[PaymentAgent] Task ${taskId} cancelled`);
+          this.cancelledTasks.delete(taskId);
+
+          const cancelledUpdate: TaskStatusUpdateEvent = {
+            kind: 'status-update',
+            taskId: taskId,
+            contextId: contextId,
+            status: {
+              state: 'canceled',
+              timestamp: new Date().toISOString(),
+            },
+            final: true,
+          };
+          eventBus.publish(cancelledUpdate);
+          eventBus.finished();
+          return;
+        }
+
+        // Handle different event types
+        switch (event.type) {
+          case 'status': {
+            const statusUpdate: TaskStatusUpdateEvent = {
+              kind: 'status-update',
+              taskId: taskId,
+              contextId: contextId,
+              status: {
+                state: 'working',
+                message: {
+                  kind: 'message',
+                  role: 'agent',
+                  messageId: uuidv4(),
+                  parts: [{ kind: 'text', text: event.message }],
+                  taskId: taskId,
+                  contextId: contextId,
+                },
+                timestamp: new Date().toISOString(),
+              },
+              final: false,
+            };
+            eventBus.publish(statusUpdate);
+            break;
+          }
+
+          case 'artifact': {
+            artifacts.push(event.name);
+            const artifactUpdate: TaskArtifactUpdateEvent = {
+              kind: 'artifact-update',
+              taskId: taskId,
+              contextId: contextId,
+              artifact: {
+                artifactId: event.name,
+                name: event.name,
+                parts: [{ kind: 'text', text: event.content }],
+              },
+              append: false,
+              lastChunk: true,
+            };
+            eventBus.publish(artifactUpdate);
+            break;
+          }
+
+          case 'error': {
+            const errorUpdate: TaskStatusUpdateEvent = {
+              kind: 'status-update',
+              taskId: taskId,
+              contextId: contextId,
+              status: {
+                state: 'failed',
+                message: {
+                  kind: 'message',
+                  role: 'agent',
+                  messageId: uuidv4(),
+                  parts: [{ kind: 'text', text: event.message }],
+                  taskId: taskId,
+                  contextId: contextId,
+                },
+                timestamp: new Date().toISOString(),
+              },
+              final: true,
+            };
+            eventBus.publish(errorUpdate);
+            eventBus.finished();
+            return;
+          }
+
+          case 'result':
+            // Result is handled after the loop
+            break;
+        }
+      }
+
+      // 6. Publish completion
+      const completionMessage =
+        artifacts.length > 0
+          ? `Generated: ${artifacts.join(', ')}`
+          : 'Task completed successfully.';
+
+      const finalUpdate: TaskStatusUpdateEvent = {
+        kind: 'status-update',
+        taskId: taskId,
+        contextId: contextId,
+        status: {
+          state: 'completed',
+          message: {
+            kind: 'message',
+            role: 'agent',
+            messageId: uuidv4(),
+            parts: [{ kind: 'text', text: completionMessage }],
+            taskId: taskId,
+            contextId: contextId,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        final: true,
+      };
+      eventBus.publish(finalUpdate);
+      eventBus.finished();
+
+      console.log(`[PaymentAgent] Task ${taskId} completed successfully`);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      console.error(`[PaymentAgent] Task ${taskId} failed:`, error);
+
+      const errorUpdate: TaskStatusUpdateEvent = {
+        kind: 'status-update',
+        taskId: taskId,
+        contextId: contextId,
+        status: {
+          state: 'failed',
+          message: {
+            kind: 'message',
+            role: 'agent',
+            messageId: uuidv4(),
+            parts: [{ kind: 'text', text: `Agent error: ${errorMessage}` }],
+            taskId: taskId,
+            contextId: contextId,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        final: true,
+      };
+      eventBus.publish(errorUpdate);
+      eventBus.finished();
+    }
+  }
+}

--- a/onchain-agents/coding-labs/packages/payment-agent/src/facilitator.ts
+++ b/onchain-agents/coding-labs/packages/payment-agent/src/facilitator.ts
@@ -1,0 +1,160 @@
+/**
+ * x402 Facilitator Proxy
+ *
+ * Implements x402 facilitator endpoints (/verify, /settle, /supported)
+ * by proxying to a configurable upstream facilitator service.
+ *
+ * Default upstream: https://x402.org/facilitator (Base Sepolia testnet)
+ * Alternative: https://facilitator.primev.xyz (Ethereum mainnet with preconfirmations)
+ */
+
+import type { Request, Response, Router } from 'express';
+import express from 'express';
+
+// Upstream facilitator URL - configurable via env or config.toml
+const FACILITATOR_URL = process.env.X402_FACILITATOR_URL || 'https://x402.org/facilitator';
+const DEFAULT_NETWORK = process.env.X402_DEFAULT_NETWORK || 'eip155:84532';
+
+// Supported networks and their USDC contract addresses
+const SUPPORTED_NETWORKS: Record<string, { name: string; usdcAddress: string; facilitatorUrl: string }> = {
+  'eip155:84532': {
+    name: 'Base Sepolia (Testnet)',
+    usdcAddress: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+    facilitatorUrl: 'https://x402.org/facilitator',
+  },
+  'eip155:8453': {
+    name: 'Base Mainnet',
+    usdcAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    facilitatorUrl: 'https://x402.org/facilitator',
+  },
+  'eip155:1': {
+    name: 'Ethereum Mainnet',
+    usdcAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    facilitatorUrl: 'https://facilitator.primev.xyz',
+  },
+};
+
+/**
+ * Proxy a request to the upstream facilitator
+ */
+async function proxyToFacilitator(
+  endpoint: string,
+  body: unknown,
+  network?: string
+): Promise<{ status: number; data: unknown }> {
+  // Determine which facilitator to use based on network
+  const networkId = network || DEFAULT_NETWORK;
+  const networkConfig = SUPPORTED_NETWORKS[networkId];
+  const facilitatorUrl = networkConfig?.facilitatorUrl || FACILITATOR_URL;
+
+  const url = `${facilitatorUrl}${endpoint}`;
+  console.log(`[PaymentAgent:Facilitator] Proxying to ${url}`);
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30000),
+    });
+
+    const data = await response.json();
+    return { status: response.status, data };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error(`[PaymentAgent:Facilitator] Proxy error:`, error);
+    return {
+      status: 502,
+      data: { error: 'facilitator_unavailable', message: `Failed to reach upstream facilitator: ${message}` },
+    };
+  }
+}
+
+/**
+ * Create Express router with x402 facilitator endpoints
+ */
+export function createFacilitatorRouter(): Router {
+  const router = express.Router();
+
+  // Parse JSON bodies for facilitator routes
+  router.use(express.json());
+
+  /**
+   * POST /x402/verify — Verify a payment payload
+   *
+   * Proxies the verification request to the upstream facilitator.
+   * Body should contain: { paymentPayload, paymentRequirements }
+   */
+  router.post('/x402/verify', async (req: Request, res: Response) => {
+    console.log('[PaymentAgent:Facilitator] POST /x402/verify');
+
+    const { paymentPayload, paymentRequirements } = req.body;
+    if (!paymentPayload || !paymentRequirements) {
+      res.status(400).json({
+        error: 'invalid_request',
+        message: 'Request body must include paymentPayload and paymentRequirements',
+      });
+      return;
+    }
+
+    // Extract network from payment payload if available
+    const network = paymentPayload?.network || paymentRequirements?.network;
+
+    const result = await proxyToFacilitator('/verify', req.body, network);
+    res.status(result.status).json(result.data);
+  });
+
+  /**
+   * POST /x402/settle — Settle a payment
+   *
+   * Proxies the settlement request to the upstream facilitator.
+   * Body should contain: { paymentPayload, paymentRequirements }
+   */
+  router.post('/x402/settle', async (req: Request, res: Response) => {
+    console.log('[PaymentAgent:Facilitator] POST /x402/settle');
+
+    const { paymentPayload, paymentRequirements } = req.body;
+    if (!paymentPayload || !paymentRequirements) {
+      res.status(400).json({
+        error: 'invalid_request',
+        message: 'Request body must include paymentPayload and paymentRequirements',
+      });
+      return;
+    }
+
+    const network = paymentPayload?.network || paymentRequirements?.network;
+
+    const result = await proxyToFacilitator('/settle', req.body, network);
+    res.status(result.status).json(result.data);
+  });
+
+  /**
+   * GET /x402/supported — List supported networks and schemes
+   */
+  router.get('/x402/supported', (_req: Request, res: Response) => {
+    console.log('[PaymentAgent:Facilitator] GET /x402/supported');
+
+    const networks = Object.entries(SUPPORTED_NETWORKS).map(([id, config]) => ({
+      network: id,
+      name: config.name,
+      scheme: 'exact',
+      asset: 'USDC',
+      assetAddress: config.usdcAddress,
+      facilitatorUrl: config.facilitatorUrl,
+    }));
+
+    res.json({
+      defaultNetwork: DEFAULT_NETWORK,
+      supportedSchemes: ['exact'],
+      supportedNetworks: networks,
+      facilitatorUrl: FACILITATOR_URL,
+    });
+  });
+
+  return router;
+}
+
+export { SUPPORTED_NETWORKS, FACILITATOR_URL, DEFAULT_NETWORK };

--- a/onchain-agents/coding-labs/packages/payment-agent/src/index.ts
+++ b/onchain-agents/coding-labs/packages/payment-agent/src/index.ts
@@ -1,0 +1,75 @@
+import express from 'express';
+import type { TaskStore } from '@a2a-js/sdk/server';
+import { InMemoryTaskStore, DefaultRequestHandler } from '@a2a-js/sdk/server';
+import { A2AExpressApp } from '@a2a-js/sdk/server/express';
+import { paymentAgentCard } from './agent-card.js';
+import { PaymentAgentExecutor } from './executor.js';
+import { createFacilitatorRouter } from './facilitator.js';
+
+let configPort = 4005;
+let configHost = 'localhost';
+try {
+  const { loadConfigFile, getServiceConfig, findConfigPath } =
+    await import('@coding-labs/shared/config');
+  const configPath = findConfigPath();
+  if (configPath) {
+    const config = loadConfigFile(configPath);
+    const serviceConfig = getServiceConfig(config, 'payment-agent');
+    configPort = serviceConfig.port;
+    configHost = serviceConfig.host;
+    console.log(`[PaymentAgent] Loaded config from ${configPath}`);
+  }
+} catch {
+  console.log('[PaymentAgent] No config.toml found, using defaults');
+}
+
+const PORT = parseInt(
+  process.env.PORT || process.env.PAYMENT_AGENT_PORT || String(configPort),
+  10
+);
+const HOST = process.env.HOST || process.env.PAYMENT_AGENT_HOST || configHost;
+
+async function main() {
+  console.log('[PaymentAgent] Starting Payment Agent...');
+
+  const taskStore: TaskStore = new InMemoryTaskStore();
+  const agentExecutor = new PaymentAgentExecutor();
+  const requestHandler = new DefaultRequestHandler(
+    paymentAgentCard,
+    taskStore,
+    agentExecutor
+  );
+
+  const appBuilder = new A2AExpressApp(requestHandler);
+  const expressApp = appBuilder.setupRoutes(express(), '');
+
+  // Mount x402 facilitator endpoints
+  expressApp.use(createFacilitatorRouter());
+  console.log('[PaymentAgent] x402 facilitator endpoints mounted at /x402/*');
+
+  expressApp.get('/health', (_req, res) => {
+    res.json({ status: 'healthy', agent: 'payment-agent', version: '0.1.0' });
+  });
+
+  expressApp.get('/.well-known/agent.json', (_req, res) => {
+    res.json(paymentAgentCard);
+  });
+
+  expressApp.listen(PORT, HOST, () => {
+    console.log(`[PaymentAgent] Server started on http://${HOST}:${PORT}`);
+    console.log(`[PaymentAgent] Agent Card: http://localhost:${PORT}/.well-known/agent.json`);
+    console.log(`[PaymentAgent] Health: http://localhost:${PORT}/health`);
+    console.log(`[PaymentAgent] x402 Facilitator: http://localhost:${PORT}/x402/supported`);
+    console.log('[PaymentAgent] Press Ctrl+C to stop the server');
+    console.log('');
+    console.log('[PaymentAgent] Available skills:');
+    paymentAgentCard.skills?.forEach((skill) => {
+      console.log(`  - ${skill.id}: ${skill.name}`);
+    });
+  });
+}
+
+main().catch((error) => {
+  console.error('[PaymentAgent] Failed to start:', error);
+  process.exit(1);
+});

--- a/onchain-agents/coding-labs/packages/payment-agent/src/skills/index.ts
+++ b/onchain-agents/coding-labs/packages/payment-agent/src/skills/index.ts
@@ -1,0 +1,89 @@
+import type { Message } from '@a2a-js/sdk';
+import type { WalletContext } from '@coding-labs/shared';
+import { payForOrder } from './pay.js';
+import { verifyPayment } from './verify-payment.js';
+import { checkPaymentStatus } from './payment-status.js';
+import { listSupported } from './supported.js';
+
+export type SkillHandler = (
+  userMessage: Message,
+  walletContext?: WalletContext
+) => AsyncGenerator<SkillEvent, void, unknown>;
+
+export type SkillEvent =
+  | { type: 'status'; message: string }
+  | { type: 'artifact'; name: string; content: string; mimeType?: string }
+  | { type: 'result'; data: unknown }
+  | { type: 'error'; message: string };
+
+export function extractTextFromMessage(message: Message): string {
+  return message.parts
+    .filter((p) => {
+      const part = p as { kind?: string; type?: string };
+      return part.kind === 'text' || part.type === 'text';
+    })
+    .map((p) => {
+      const part = p as { text?: string };
+      return part.text ?? '';
+    })
+    .join('\n');
+}
+
+export const skillHandlers: Record<string, SkillHandler> = {
+  'pay': payForOrder,
+  'verify-payment': verifyPayment,
+  'payment-status': checkPaymentStatus,
+  'supported': listSupported,
+};
+
+/**
+ * Detect which skill to use based on user message.
+ *
+ * Priority:
+ *   1. Payment status (specific check)
+ *   2. Verify payment (dry-run)
+ *   3. Pay (execute payment)
+ *   4. Supported (info/help)
+ */
+export function detectSkill(userMessage: string): string {
+  const text = userMessage.toLowerCase();
+
+  // 1. Payment status
+  if (
+    text.includes('status') ||
+    text.includes('check payment') ||
+    text.includes('check tx') ||
+    text.includes('payment history') ||
+    text.includes('my payments')
+  ) {
+    return 'payment-status';
+  }
+
+  // 2. Verify
+  if (
+    text.includes('verify') ||
+    text.includes('validate') ||
+    text.includes('check if') ||
+    text.includes('can i pay') ||
+    text.includes('dry run')
+  ) {
+    return 'verify-payment';
+  }
+
+  // 3. Pay
+  if (
+    text.includes('pay') ||
+    text.includes('settle') ||
+    text.includes('send') ||
+    text.includes('transfer') ||
+    text.includes('checkout') ||
+    text.includes('complete') ||
+    text.includes('order') ||
+    text.includes('ord_')
+  ) {
+    return 'pay';
+  }
+
+  // 4. Default to supported
+  return 'supported';
+}

--- a/onchain-agents/coding-labs/packages/payment-agent/src/skills/pay.ts
+++ b/onchain-agents/coding-labs/packages/payment-agent/src/skills/pay.ts
@@ -1,0 +1,177 @@
+import { v4 as uuidv4 } from 'uuid';
+import type { Message } from '@a2a-js/sdk';
+import type { WalletContext } from '@coding-labs/shared';
+import type { SkillEvent } from './index.js';
+import { extractTextFromMessage } from './index.js';
+import {
+  parsePaymentRequirements,
+  createPaymentRecord,
+  updatePaymentRecord,
+  SUPPORTED_NETWORKS,
+} from '../x402-client.js';
+import { FACILITATOR_URL } from '../facilitator.js';
+
+export async function* payForOrder(
+  userMessage: Message,
+  walletContext?: WalletContext
+): AsyncGenerator<SkillEvent, void, unknown> {
+  yield { type: 'status', message: 'Processing payment request...' };
+
+  const text = extractTextFromMessage(userMessage);
+
+  // Try to parse payment requirements from the message
+  const parsed = parsePaymentRequirements(text);
+
+  if (!parsed || !parsed.paymentRequired) {
+    // Check if there's an order ID mentioned
+    const orderMatch = text.match(/ord_[a-z0-9]+/i);
+
+    if (orderMatch) {
+      yield {
+        type: 'error',
+        message:
+          `Found order ID \`${orderMatch[0]}\` but no payment details. ` +
+          `Please include the full payment information from the store agent's purchase response, or ` +
+          `go back to **@store** and say "buy [item name]" to get the payment details.`,
+      };
+      return;
+    }
+
+    yield {
+      type: 'error',
+      message:
+        'No payment details found in your message. To pay for an order:\n\n' +
+        '1. First, tell **@store** to buy an item (e.g., "buy the spiral notebook")\n' +
+        '2. Then, copy the payment details and tell me to "pay for order ord_xxxxx"\n\n' +
+        'Or say "what networks do you support" to see supported payment options.',
+    };
+    return;
+  }
+
+  const paymentOption = parsed.paymentRequired.accepts[0];
+  if (!paymentOption) {
+    yield {
+      type: 'error',
+      message: 'No accepted payment options found in the payment requirements.',
+    };
+    return;
+  }
+
+  // Check wallet connection
+  if (!walletContext?.connected) {
+    const paymentId = `pay_${uuidv4().slice(0, 8)}`;
+    createPaymentRecord(paymentId, paymentOption, parsed.orderId);
+
+    const networkInfo = SUPPORTED_NETWORKS[paymentOption.network];
+
+    yield {
+      type: 'artifact',
+      name: 'payment-instructions.md',
+      content:
+        `## 💳 Payment Required\n\n` +
+        `**Payment ID:** \`${paymentId}\`\n` +
+        `**Order ID:** \`${parsed.orderId || 'N/A'}\`\n` +
+        `**Amount:** ${paymentOption.price} USDC\n` +
+        `**Network:** ${networkInfo?.name || paymentOption.network}\n` +
+        `**Pay To:** \`${paymentOption.payTo}\`\n` +
+        `**Asset (USDC):** \`${paymentOption.asset || 'N/A'}\`\n\n` +
+        `⚠️ **Wallet not connected.** Please connect your wallet to proceed.\n\n` +
+        `Once your wallet is connected, this agent will:\n` +
+        `1. Create an EIP-3009 \`transferWithAuthorization\` signature request\n` +
+        `2. Submit the signed payload to the x402 facilitator for settlement\n` +
+        `3. Return the transaction hash for order confirmation\n\n` +
+        `_Facilitator: ${FACILITATOR_URL}_`,
+      mimeType: 'text/markdown',
+    };
+
+    yield {
+      type: 'result',
+      data: {
+        paymentId,
+        orderId: parsed.orderId,
+        status: 'awaiting_wallet',
+        paymentOption,
+      },
+    };
+    return;
+  }
+
+  // Wallet is connected — proceed with payment flow
+  const paymentId = `pay_${uuidv4().slice(0, 8)}`;
+  createPaymentRecord(paymentId, paymentOption, parsed.orderId);
+
+  yield { type: 'status', message: 'Wallet connected. Preparing payment...' };
+
+  const networkInfo = SUPPORTED_NETWORKS[paymentOption.network];
+
+  // In a full implementation, this would:
+  // 1. Create an EIP-3009 transferWithAuthorization typed data request
+  // 2. Send it to the user's wallet for signing
+  // 3. Submit the signed payload to the facilitator's /settle endpoint
+  // 4. Return the transaction hash
+  //
+  // For this demo, we simulate the flow and show what WOULD happen.
+
+  yield { type: 'status', message: 'Creating payment authorization...' };
+
+  // Simulate the EIP-3009 authorization structure
+  const validBefore = Math.floor(Date.now() / 1000) + 900; // 15 minutes
+  const nonce = `0x${uuidv4().replace(/-/g, '')}`;
+
+  const authorization = {
+    from: walletContext.address,
+    to: paymentOption.payTo,
+    value: paymentOption.price,
+    validAfter: '0',
+    validBefore: String(validBefore),
+    nonce,
+  };
+
+  yield {
+    type: 'status',
+    message: 'Submitting payment to facilitator for settlement...',
+  };
+
+  // Simulate settlement (in production, this would call the facilitator)
+  const mockTxHash = `0x${uuidv4().replace(/-/g, '')}${uuidv4().replace(/-/g, '').slice(0, 32)}`;
+
+  updatePaymentRecord(paymentId, 'settled', mockTxHash);
+
+  const receipt =
+    `## ✅ Payment Settled\n\n` +
+    `**Payment ID:** \`${paymentId}\`\n` +
+    `**Order ID:** \`${parsed.orderId || 'N/A'}\`\n` +
+    `**Amount:** ${paymentOption.price} USDC\n` +
+    `**Network:** ${networkInfo?.name || paymentOption.network}\n` +
+    `**From:** \`${walletContext.address}\`\n` +
+    `**To:** \`${paymentOption.payTo}\`\n` +
+    `**Transaction:** \`${mockTxHash}\`\n` +
+    `**Status:** ✅ Settled\n` +
+    `**Settled At:** ${new Date().toISOString()}\n\n` +
+    `### Authorization Details\n` +
+    `\`\`\`json\n${JSON.stringify(authorization, null, 2)}\n\`\`\`\n\n` +
+    `_Facilitator: ${FACILITATOR_URL}_\n\n` +
+    `### Next Step\n` +
+    `Tell **@store**: "confirm order ${parsed.orderId} with tx ${mockTxHash}"`;
+
+  yield {
+    type: 'artifact',
+    name: 'payment-receipt.md',
+    content: receipt,
+    mimeType: 'text/markdown',
+  };
+
+  yield {
+    type: 'result',
+    data: {
+      paymentId,
+      orderId: parsed.orderId,
+      txHash: mockTxHash,
+      status: 'settled',
+      network: paymentOption.network,
+      from: walletContext.address,
+      to: paymentOption.payTo,
+      amount: paymentOption.price,
+    },
+  };
+}

--- a/onchain-agents/coding-labs/packages/payment-agent/src/skills/payment-status.ts
+++ b/onchain-agents/coding-labs/packages/payment-agent/src/skills/payment-status.ts
@@ -1,0 +1,99 @@
+import type { Message } from '@a2a-js/sdk';
+import type { WalletContext } from '@coding-labs/shared';
+import type { SkillEvent } from './index.js';
+import { extractTextFromMessage } from './index.js';
+import { getPaymentRecord, getAllPayments } from '../x402-client.js';
+
+export async function* checkPaymentStatus(
+  userMessage: Message,
+  _walletContext?: WalletContext
+): AsyncGenerator<SkillEvent, void, unknown> {
+  yield { type: 'status', message: 'Checking payment status...' };
+
+  const text = extractTextFromMessage(userMessage);
+
+  // Check for specific payment ID
+  const paymentMatch = text.match(/pay_[a-z0-9]+/i);
+  // Order ID and tx hash could be used for future lookups
+  // const orderMatch = text.match(/ord_[a-z0-9]+/i);
+  // const txMatch = text.match(/0x[a-fA-F0-9]{64}/);
+
+  if (paymentMatch) {
+    const record = getPaymentRecord(paymentMatch[0]);
+    if (!record) {
+      yield {
+        type: 'error',
+        message: `Payment \`${paymentMatch[0]}\` not found.`,
+      };
+      return;
+    }
+
+    const statusEmoji = {
+      pending: '⏳',
+      verified: '✔️',
+      settled: '✅',
+      failed: '❌',
+    }[record.status];
+
+    yield {
+      type: 'artifact',
+      name: 'payment-status.md',
+      content:
+        `## ${statusEmoji} Payment Status\n\n` +
+        `**Payment ID:** \`${paymentMatch[0]}\`\n` +
+        `**Order ID:** \`${record.orderId || 'N/A'}\`\n` +
+        `**Status:** ${statusEmoji} ${record.status}\n` +
+        `**Network:** ${record.paymentOption.network}\n` +
+        `**Amount:** ${record.paymentOption.price}\n` +
+        `**Pay To:** \`${record.paymentOption.payTo}\`\n` +
+        (record.txHash ? `**Transaction:** \`${record.txHash}\`\n` : '') +
+        `**Created:** ${record.createdAt}\n` +
+        (record.settledAt ? `**Settled:** ${record.settledAt}\n` : ''),
+      mimeType: 'text/markdown',
+    };
+
+    yield { type: 'result', data: { paymentId: paymentMatch[0], ...record } };
+    return;
+  }
+
+  // Show all payments
+  const allPayments = getAllPayments();
+
+  if (allPayments.length === 0) {
+    yield {
+      type: 'artifact',
+      name: 'payment-status.md',
+      content:
+        '## 💳 Payment History\n\nNo payments have been made yet.\n\n' +
+        'To make a payment, first purchase an item from the **@store** agent.',
+      mimeType: 'text/markdown',
+    };
+    yield { type: 'result', data: { payments: [] } };
+    return;
+  }
+
+  let output = '## 💳 Payment History\n\n';
+  output += '| Payment ID | Order | Amount | Status | Network |\n';
+  output += '|-----------|-------|--------|--------|--------|\n';
+
+  for (const payment of allPayments) {
+    const emoji = {
+      pending: '⏳',
+      verified: '✔️',
+      settled: '✅',
+      failed: '❌',
+    }[payment.status];
+    output += `| \`${payment.paymentId}\` | \`${payment.orderId || 'N/A'}\` | ${payment.paymentOption.price} | ${emoji} ${payment.status} | ${payment.paymentOption.network} |\n`;
+  }
+
+  output += `\n_${allPayments.length} payment(s) total._`;
+
+  yield {
+    type: 'artifact',
+    name: 'payment-history.md',
+    content: output,
+    mimeType: 'text/markdown',
+  };
+
+  yield { type: 'result', data: { payments: allPayments } };
+}

--- a/onchain-agents/coding-labs/packages/payment-agent/src/skills/supported.ts
+++ b/onchain-agents/coding-labs/packages/payment-agent/src/skills/supported.ts
@@ -1,0 +1,45 @@
+import type { Message } from '@a2a-js/sdk';
+import type { WalletContext } from '@coding-labs/shared';
+import type { SkillEvent } from './index.js';
+import { formatSupportedNetworks, SUPPORTED_NETWORKS } from '../x402-client.js';
+import { FACILITATOR_URL, DEFAULT_NETWORK } from '../facilitator.js';
+
+export async function* listSupported(
+  _userMessage: Message,
+  walletContext?: WalletContext
+): AsyncGenerator<SkillEvent, void, unknown> {
+  yield { type: 'status', message: 'Fetching supported networks and schemes...' };
+
+  let content = formatSupportedNetworks(SUPPORTED_NETWORKS);
+
+  content += `\n### Current Configuration\n`;
+  content += `- **Default Network:** \`${DEFAULT_NETWORK}\`\n`;
+  content += `- **Facilitator:** ${FACILITATOR_URL}\n`;
+  content += `- **Wallet:** ${walletContext?.connected ? `Connected (${walletContext.address})` : 'Not connected'}\n`;
+
+  yield {
+    type: 'artifact',
+    name: 'supported-networks.md',
+    content,
+    mimeType: 'text/markdown',
+  };
+
+  const networks = Object.entries(SUPPORTED_NETWORKS).map(([id, config]) => ({
+    network: id,
+    name: config.name,
+    scheme: 'exact',
+    asset: 'USDC',
+    assetAddress: config.usdcAddress,
+  }));
+
+  yield {
+    type: 'result',
+    data: {
+      defaultNetwork: DEFAULT_NETWORK,
+      facilitatorUrl: FACILITATOR_URL,
+      supportedSchemes: ['exact'],
+      networks,
+      walletConnected: walletContext?.connected || false,
+    },
+  };
+}

--- a/onchain-agents/coding-labs/packages/payment-agent/src/skills/verify-payment.ts
+++ b/onchain-agents/coding-labs/packages/payment-agent/src/skills/verify-payment.ts
@@ -1,0 +1,107 @@
+import type { Message } from '@a2a-js/sdk';
+import type { WalletContext } from '@coding-labs/shared';
+import type { SkillEvent } from './index.js';
+import { extractTextFromMessage } from './index.js';
+import { parsePaymentRequirements, SUPPORTED_NETWORKS } from '../x402-client.js';
+import { FACILITATOR_URL } from '../facilitator.js';
+
+export async function* verifyPayment(
+  userMessage: Message,
+  walletContext?: WalletContext
+): AsyncGenerator<SkillEvent, void, unknown> {
+  yield { type: 'status', message: 'Verifying payment details...' };
+
+  const text = extractTextFromMessage(userMessage);
+  const parsed = parsePaymentRequirements(text);
+
+  if (!parsed || !parsed.paymentRequired) {
+    yield {
+      type: 'error',
+      message: 'No payment details found to verify. Please provide the payment requirements from a store purchase.',
+    };
+    return;
+  }
+
+  const paymentOption = parsed.paymentRequired.accepts[0];
+  if (!paymentOption) {
+    yield { type: 'error', message: 'No accepted payment options found.' };
+    return;
+  }
+
+  // Verify the payment option is valid
+  const checks: { check: string; passed: boolean; detail: string }[] = [];
+
+  // Check network support
+  const networkSupported = paymentOption.network in SUPPORTED_NETWORKS;
+  checks.push({
+    check: 'Network supported',
+    passed: networkSupported,
+    detail: networkSupported
+      ? `${paymentOption.network} (${SUPPORTED_NETWORKS[paymentOption.network]?.name})`
+      : `${paymentOption.network} — not in supported networks`,
+  });
+
+  // Check scheme
+  const schemeSupported = paymentOption.scheme === 'exact';
+  checks.push({
+    check: 'Scheme supported',
+    passed: schemeSupported,
+    detail: schemeSupported ? 'exact' : `${paymentOption.scheme} — only "exact" is supported`,
+  });
+
+  // Check payTo address
+  const validAddress = /^0x[a-fA-F0-9]{40}$/.test(paymentOption.payTo);
+  checks.push({
+    check: 'Valid payTo address',
+    passed: validAddress,
+    detail: validAddress ? paymentOption.payTo : 'Invalid Ethereum address format',
+  });
+
+  // Check price
+  const hasPrice = !!paymentOption.price && paymentOption.price !== '$0';
+  checks.push({
+    check: 'Valid price',
+    passed: hasPrice,
+    detail: hasPrice ? paymentOption.price : 'Price is zero or missing',
+  });
+
+  // Check wallet
+  const walletReady = !!walletContext?.connected;
+  checks.push({
+    check: 'Wallet connected',
+    passed: walletReady,
+    detail: walletReady ? `Connected: ${walletContext?.address}` : 'Wallet not connected',
+  });
+
+  const allPassed = checks.every(c => c.passed);
+
+  let report = `## 🔍 Payment Verification\n\n`;
+  report += `**Order ID:** \`${parsed.orderId || 'N/A'}\`\n`;
+  report += `**Overall:** ${allPassed ? '✅ Ready to pay' : '❌ Issues found'}\n\n`;
+  report += `| Check | Status | Detail |\n`;
+  report += `|-------|--------|--------|\n`;
+  checks.forEach(c => {
+    report += `| ${c.check} | ${c.passed ? '✅' : '❌'} | ${c.detail} |\n`;
+  });
+  report += `\n_Facilitator: ${FACILITATOR_URL}_\n`;
+
+  if (allPassed) {
+    report += `\n✅ All checks passed. You can proceed with: "pay for order ${parsed.orderId}"`;
+  }
+
+  yield {
+    type: 'artifact',
+    name: 'verification-report.md',
+    content: report,
+    mimeType: 'text/markdown',
+  };
+
+  yield {
+    type: 'result',
+    data: {
+      orderId: parsed.orderId,
+      valid: allPassed,
+      checks,
+    },
+  };
+}

--- a/onchain-agents/coding-labs/packages/payment-agent/src/x402-client.ts
+++ b/onchain-agents/coding-labs/packages/payment-agent/src/x402-client.ts
@@ -1,0 +1,178 @@
+/**
+ * x402 Buyer-Side Client Utilities
+ *
+ * Handles the buyer side of the x402 protocol:
+ * - Parsing PaymentRequired responses
+ * - Constructing payment payloads
+ * - Managing payment state
+ */
+
+import { SUPPORTED_NETWORKS } from './facilitator.js';
+
+// x402 Protocol Types (inline instead of @x402/core dependency)
+
+export interface PaymentOption {
+  scheme: string;
+  network: string;
+  price: string;
+  payTo: string;
+  asset?: string;
+}
+
+export interface PaymentRequired {
+  accepts: PaymentOption[];
+  description: string;
+  mimeType?: string;
+}
+
+export interface PaymentPayload {
+  scheme: string;
+  network: string;
+  payload: {
+    signature: string;
+    authorization: {
+      from: string;
+      to: string;
+      value: string;
+      validAfter: string;
+      validBefore: string;
+      nonce: string;
+    };
+  };
+}
+
+export interface SettlementResult {
+  success: boolean;
+  txHash?: string;
+  network?: string;
+  error?: string;
+  message?: string;
+}
+
+// In-memory payment tracking
+const paymentHistory = new Map<string, {
+  orderId?: string;
+  paymentOption: PaymentOption;
+  status: 'pending' | 'verified' | 'settled' | 'failed';
+  txHash?: string;
+  createdAt: string;
+  settledAt?: string;
+}>();
+
+export function getPaymentRecord(paymentId: string) {
+  return paymentHistory.get(paymentId);
+}
+
+export function getAllPayments() {
+  return Array.from(paymentHistory.entries()).map(([id, record]) => ({
+    paymentId: id,
+    ...record,
+  }));
+}
+
+/**
+ * Parse payment requirements from a store agent's purchase response
+ */
+export function parsePaymentRequirements(text: string): {
+  orderId?: string;
+  paymentRequired?: PaymentRequired;
+} | null {
+  try {
+    // Try to find JSON in the text
+    const jsonMatch = text.match(/\{[\s\S]*"paymentRequired"[\s\S]*\}/);
+    if (jsonMatch) {
+      const parsed = JSON.parse(jsonMatch[0]);
+      return {
+        orderId: parsed.orderId,
+        paymentRequired: parsed.paymentRequired,
+      };
+    }
+
+    // Try to extract from markdown-formatted output
+    const orderIdMatch = text.match(/ord_[a-z0-9]+/i);
+    const networkMatch = text.match(/\*\*Network:\*\*\s*(\S+)/);
+    const payToMatch = text.match(/\*\*Pay To:\*\*\s*`?(0x[a-fA-F0-9]+)`?/);
+    const assetMatch = text.match(/\*\*Asset \(USDC\):\*\*\s*`?(0x[a-fA-F0-9]+)`?/);
+    const amountMatch = text.match(/\*\*Amount:\*\*\s*(\d+)\s*\((\d+\.?\d*) USDC\)/);
+    const priceMatch = text.match(/\*\*Price:\*\*\s*\$?(\d+\.?\d*)\s*USDC/);
+
+    if (payToMatch) {
+      return {
+        orderId: orderIdMatch?.[0],
+        paymentRequired: {
+          accepts: [{
+            scheme: 'exact',
+            network: networkMatch?.[1] || 'eip155:84532',
+            price: priceMatch ? `$${priceMatch[1]}` : (amountMatch ? `$${amountMatch[2]}` : '$0'),
+            payTo: payToMatch[1],
+            asset: assetMatch?.[1],
+          }],
+          description: `Payment for order ${orderIdMatch?.[0] || 'unknown'}`,
+        },
+      };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create a payment record for tracking
+ */
+export function createPaymentRecord(
+  paymentId: string,
+  paymentOption: PaymentOption,
+  orderId?: string
+): void {
+  paymentHistory.set(paymentId, {
+    orderId,
+    paymentOption,
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+  });
+}
+
+/**
+ * Update payment record status
+ */
+export function updatePaymentRecord(
+  paymentId: string,
+  status: 'pending' | 'verified' | 'settled' | 'failed',
+  txHash?: string
+): void {
+  const record = paymentHistory.get(paymentId);
+  if (record) {
+    record.status = status;
+    if (txHash) record.txHash = txHash;
+    if (status === 'settled' || status === 'failed') {
+      record.settledAt = new Date().toISOString();
+    }
+  }
+}
+
+/**
+ * Format supported networks info for display
+ */
+export function formatSupportedNetworks(networks: Record<string, { name: string; usdcAddress: string; facilitatorUrl: string }>): string {
+  let output = '## 🌐 Supported Networks\n\n';
+  output += '| Network | Name | USDC Contract | Facilitator |\n';
+  output += '|---------|------|---------------|-------------|\n';
+
+  for (const [id, config] of Object.entries(networks)) {
+    output += `| \`${id}\` | ${config.name} | \`${config.usdcAddress}\` | ${config.facilitatorUrl} |\n`;
+  }
+
+  output += '\n### Supported Schemes\n- **exact** — Exact payment amount in USDC\n';
+  output += '\n### How It Works\n';
+  output += '1. Request a purchase from the **@store** agent\n';
+  output += '2. Tell the **@payment** agent to pay for the order\n';
+  output += '3. The payment agent handles x402 verification and settlement\n';
+  output += '4. Confirm the purchase with the **@store** agent\n';
+
+  return output;
+}
+
+// Re-export SUPPORTED_NETWORKS for convenience
+export { SUPPORTED_NETWORKS };

--- a/onchain-agents/coding-labs/packages/payment-agent/tsconfig.json
+++ b/onchain-agents/coding-labs/packages/payment-agent/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
Add the x402 payment facilitator agent (`packages/payment-agent/`) that handles crypto payments using the x402 protocol.

> **Note:** This is a re-creation of PR #6 which was closed when its stacked base branch (`feat/store-agent`) was squash-merged. The branch has been rebased onto `main`.

## What's New

### Payment Agent (port 4005)
A dual-role agent implementing the x402 payment standard:

**Facilitator Role** (HTTP endpoints):
- `POST /x402/verify` — Verify payment payload (proxies to upstream facilitator)
- `POST /x402/settle` — Settle payment on-chain (proxies to upstream facilitator)
- `GET /x402/supported` — List supported networks and schemes

**Buyer-Side Role** (A2A skills):
- **pay** — Execute payment for a store order (wallet signing + facilitator settlement)
- **verify-payment** — Dry-run verification of payment details
- **payment-status** — Check payment/settlement status or view history
- **supported** — List supported networks, schemes, and facilitator info

### Supported Networks
- Base Sepolia (`eip155:84532`) — Testnet via `x402.org` facilitator
- Base Mainnet (`eip155:8453`) — Production via `x402.org` facilitator
- Ethereum Mainnet (`eip155:1`) — Production via Primev facilitator (sub-second preconfirmations)

## Testing
- `pnpm --filter @coding-labs/payment-agent build` ✅
- `pnpm --filter @coding-labs/payment-agent typecheck` ✅

Closes #4