### PR TITLE
fix(blockchain-a2a-agent): resolve rustls CryptoProvider panic on startup

### DIFF
--- a/ai-tools/vertx-ai-studio/blockchain-a2a-agent/Cargo.lock
+++ b/ai-tools/vertx-ai-studio/blockchain-a2a-agent/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "axum",
  "gcp_auth",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "tokio",
@@ -1083,6 +1084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/ai-tools/vertx-ai-studio/blockchain-a2a-agent/Cargo.toml
+++ b/ai-tools/vertx-ai-studio/blockchain-a2a-agent/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1"
 axum = "0.8.8"
 gcp_auth = "0.12"
 reqwest = { version = "0.13.2", features = ["json"] }
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.50.0", features = ["full"] }

--- a/ai-tools/vertx-ai-studio/blockchain-a2a-agent/src/blockchain.rs
+++ b/ai-tools/vertx-ai-studio/blockchain-a2a-agent/src/blockchain.rs
@@ -89,18 +89,3 @@ pub async fn fetch_solana(client: &reqwest::Client) -> Result<NetworkResponse> {
         source: "api.mainnet-beta.solana.com".into(),
     })
 }
-
-/// Fetch all three networks in parallel, returning whatever succeeds.
-pub async fn fetch_all(client: &reqwest::Client) -> Vec<NetworkResponse> {
-    let (btc, eth, sol) = tokio::join!(
-        fetch_bitcoin(client),
-        fetch_ethereum(client),
-        fetch_solana(client),
-    );
-
-    let mut results = Vec::with_capacity(3);
-    if let Ok(r) = btc { results.push(r); }
-    if let Ok(r) = eth { results.push(r); }
-    if let Ok(r) = sol { results.push(r); }
-    results
-}

--- a/ai-tools/vertx-ai-studio/blockchain-a2a-agent/src/main.rs
+++ b/ai-tools/vertx-ai-studio/blockchain-a2a-agent/src/main.rs
@@ -228,6 +228,13 @@ async fn handle_message(
 
 #[tokio::main]
 async fn main() {
+    // Explicitly install the aws-lc-rs CryptoProvider to avoid a panic when
+    // both `aws-lc-rs` and `ring` features are enabled on rustls 0.23+ via
+    // transitive dependencies (reqwest → aws-lc-rs, gcp_auth → ring).
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("Failed to install default CryptoProvider");
+
     let http_client = reqwest::Client::new();
     let gemini = llm::GeminiClient::try_new(http_client.clone()).await;
 


### PR DESCRIPTION
## Summary

- **Fix runtime panic**: Explicitly install the `aws-lc-rs` CryptoProvider at the top of `main()` to prevent `rustls` 0.23+ from panicking when both `aws-lc-rs` and `ring` features are enabled via transitive dependencies (`reqwest` → `aws-lc-rs`, `gcp_auth` → `ring`)
- **Add `rustls` as direct dependency** in `Cargo.toml` with the `aws-lc-rs` feature to ensure the provider is available
- **Remove dead code**: Delete unused `fetch_all` function from `blockchain.rs` to eliminate compiler warning

## Changes

| File | Change |
|------|--------|
| `blockchain-a2a-agent/Cargo.toml` | Add `rustls = { version = "0.23", features = ["aws-lc-rs"] }` |
| `blockchain-a2a-agent/src/main.rs` | Add `CryptoProvider::install_default()` call at top of `main()` |
| `blockchain-a2a-agent/src/blockchain.rs` | Remove unused `fetch_all` function |
| `blockchain-a2a-agent/Cargo.lock` | Updated lockfile |

## Testing

- ✅ `cargo build --release` — zero warnings
- ✅ `cargo test` — 5/5 tests pass

Closes #12