### PR TITLE
fix(llm): correct Vertex AI global endpoint URL and update model default

### DIFF
--- a/ai-tools/vertx-ai-studio/blockchain-a2a-agent/Makefile
+++ b/ai-tools/vertx-ai-studio/blockchain-a2a-agent/Makefile
@@ -6,8 +6,8 @@
 
 # Configurable variables (override via env or command line)
 GOOGLE_CLOUD_PROJECT ?= $(shell gcloud config get-value project 2>/dev/null)
-VERTEX_LOCATION      ?= us-central1
-GEMINI_MODEL         ?= gemini-3.0-flash
+VERTEX_LOCATION      ?= global
+GEMINI_MODEL         ?= gemini-3.1-flash-lite-preview
 PORT                 ?= 8080
 
 .PHONY: build test run run-llm run-keyword clean fmt lint check help

--- a/ai-tools/vertx-ai-studio/blockchain-a2a-agent/src/llm.rs
+++ b/ai-tools/vertx-ai-studio/blockchain-a2a-agent/src/llm.rs
@@ -38,9 +38,9 @@ impl GeminiClient {
     pub async fn try_new(http: reqwest::Client) -> Option<Self> {
         let project = std::env::var("GOOGLE_CLOUD_PROJECT").ok()?;
         let location =
-            std::env::var("VERTEX_LOCATION").unwrap_or_else(|_| "us-central1".into());
+            std::env::var("VERTEX_LOCATION").unwrap_or_else(|_| "global".into());
         let model =
-            std::env::var("GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.0-flash".into());
+            std::env::var("GEMINI_MODEL").unwrap_or_else(|_| "gemini-3.1-flash-lite-preview".into());
 
         let auth = gcp_auth::provider()
             .await
@@ -56,8 +56,14 @@ impl GeminiClient {
         let scopes = &["https://www.googleapis.com/auth/cloud-platform"];
         let token = self.auth.token(scopes).await.context("failed to get ADC token")?;
 
+        let host = if self.location == "global" {
+            "aiplatform.googleapis.com".to_string()
+        } else {
+            format!("{}-aiplatform.googleapis.com", self.location)
+        };
         let url = format!(
-            "https://{loc}-aiplatform.googleapis.com/v1/projects/{proj}/locations/{loc}/publishers/google/models/{model}:generateContent",
+            "https://{host}/v1/projects/{proj}/locations/{loc}/publishers/google/models/{model}:generateContent",
+            host = host,
             loc = self.location,
             proj = self.project,
             model = self.model,


### PR DESCRIPTION
## Summary

- **Fix global endpoint URL**: The URL template `https://{loc}-aiplatform.googleapis.com/...` produced an invalid hostname `global-aiplatform.googleapis.com` when `loc=global`. Added conditional logic to use `aiplatform.googleapis.com` (no region prefix) for the global location.
- **Update model default**: Changed fallback model from `gemini-3.0-flash` (which never existed) to `gemini-3.1-flash-lite-preview` (verified working via curl against `kunal-scratch` project).
- **Update Makefile defaults**: Changed `VERTEX_LOCATION` from `us-central1` to `global` and `GEMINI_MODEL` to `gemini-3.1-flash-lite-preview`.

## Changes

| File | Change |
|------|--------|
| `blockchain-a2a-agent/src/llm.rs` | Conditional host construction for global vs regional endpoints; updated model and location defaults |
| `blockchain-a2a-agent/Makefile` | Updated `VERTEX_LOCATION` and `GEMINI_MODEL` defaults |

## Verification

- `cargo build --release` — ✅ zero warnings
- `cargo test` — ✅ 5/5 tests pass

Closes #14