### PR TITLE
feat(sonic-agent): add permissive CORS middleware

### DIFF
--- a/onchain-agents/coding-labs/packages/sonic-agent/package.json
+++ b/onchain-agents/coding-labs/packages/sonic-agent/package.json
@@ -12,14 +12,16 @@
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.10",
-    "@coding-labs/shared": "workspace:*",
     "@ai-sdk/google-vertex": "^3.0.98",
+    "@coding-labs/shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "ai": "^5.0.0",
+    "cors": "^2.8.6",
     "express": "^4.21.0",
     "uuid": "^11.0.0"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.0",
     "@types/node": "^22.13.0",
     "@types/uuid": "^10.0.0",

--- a/onchain-agents/coding-labs/packages/sonic-agent/src/index.ts
+++ b/onchain-agents/coding-labs/packages/sonic-agent/src/index.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import cors from 'cors';
 import type { TaskStore } from '@a2a-js/sdk/server';
 import { InMemoryTaskStore, DefaultRequestHandler } from '@a2a-js/sdk/server';
 import { A2AExpressApp } from '@a2a-js/sdk/server/express';
@@ -48,9 +49,11 @@ async function main() {
     agentExecutor
   );
 
-  // 4. Create and setup A2AExpressApp
+  // 4. Create and setup A2AExpressApp with CORS middleware
   const appBuilder = new A2AExpressApp(requestHandler);
-  const expressApp = appBuilder.setupRoutes(express(), '');
+  const app = express();
+  app.use(cors());
+  const expressApp = appBuilder.setupRoutes(app, '');
 
   // 5. Add health check endpoint
   expressApp.get('/health', (_req, res) => {

--- a/onchain-agents/coding-labs/pnpm-lock.yaml
+++ b/onchain-agents/coding-labs/pnpm-lock.yaml
@@ -145,6 +145,37 @@ importers:
         specifier: ^4.21.2
         version: 4.22.1
 
+  packages/payment-agent:
+    dependencies:
+      '@a2a-js/sdk':
+        specifier: ^0.3.10
+        version: 0.3.10(@grpc/grpc-js@1.14.3)(express@4.22.1)
+      '@coding-labs/shared':
+        specifier: workspace:*
+        version: link:../shared
+      express:
+        specifier: ^4.21.0
+        version: 4.22.1
+      uuid:
+        specifier: ^11.0.0
+        version: 11.1.0
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.13.0
+        version: 22.19.11
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+
   packages/shared:
     dependencies:
       smol-toml:
@@ -218,6 +249,43 @@ importers:
       ai:
         specifier: ^5.0.0
         version: 5.0.133(zod@4.3.6)
+      cors:
+        specifier: ^2.8.6
+        version: 2.8.6
+      express:
+        specifier: ^4.21.0
+        version: 4.22.1
+      uuid:
+        specifier: ^11.0.0
+        version: 11.1.0
+    devDependencies:
+      '@types/cors':
+        specifier: ^2.8.19
+        version: 2.8.19
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.13.0
+        version: 22.19.11
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+
+  packages/store-agent:
+    dependencies:
+      '@a2a-js/sdk':
+        specifier: ^0.3.10
+        version: 0.3.10(@grpc/grpc-js@1.14.3)(express@4.22.1)
+      '@coding-labs/shared':
+        specifier: workspace:*
+        version: link:../shared
       express:
         specifier: ^4.21.0
         version: 4.22.1
@@ -915,6 +983,9 @@ packages:
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2845,6 +2916,10 @@ snapshots:
       '@types/node': 22.19.11
 
   '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.19.11
+
+  '@types/cors@2.8.19':
     dependencies:
       '@types/node': 22.19.11
 


### PR DESCRIPTION
## Summary

- Add `cors` npm package with permissive `origin: *` configuration to the sonic-agent Express server
- Apply CORS middleware at the Express app level before `setupRoutes()` so ALL routes (A2A JSON-RPC, `/health`, `/.well-known/agent.json`) get proper CORS headers
- Enables browser-based A2A clients to make cross-origin requests to the sonic-agent

## Changes

- **`packages/sonic-agent/package.json`** — Added `cors` (^2.8.6) to dependencies and `@types/cors` (^2.8.19) to devDependencies
- **`packages/sonic-agent/src/index.ts`** — Imported `cors` and applied `app.use(cors())` before route setup
- **`pnpm-lock.yaml`** — Updated lockfile with new dependencies

## Verification

- ✅ `pnpm typecheck` passes
- ✅ `pnpm build` passes

Closes #22