### PR TITLE
chore(ui): rename sidebar nav label from dCoder to Agent Playground

### DIFF
--- a/onchain-agents/coding-labs/packages/opencode-login/public/index.html
+++ b/onchain-agents/coding-labs/packages/opencode-login/public/index.html
@@ -237,7 +237,7 @@
                   d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
                 />
               </svg>
-              <span>dCoder</span>
+              <span>Agent Playground</span>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
## Summary

- Rename the sidebar navigation label from "dCoder" to "Agent Playground" in `packages/opencode-login/public/index.html`
- Only the user-visible text changes; all internal identifiers (`data-page="dcoder"`, CSS class `nav-item-dcoder`, page IDs, JS references) remain unchanged

## Changes

Single-line change on line 240:
```diff
-              <span>dCoder</span>
+              <span>Agent Playground</span>
```

## Testing Notes

- `make test` failed due to corporate proxy/npm install issues (Corp Airlock), unrelated to this change
- The change is a cosmetic text-only rename with no logic impact

Closes #38