### PR TITLE
fix(adk-backend): move typescript to production dependencies for agent compilation

### DIFF
--- a/onchain-agents/coding-labs/packages/adk-backend/package.json
+++ b/onchain-agents/coding-labs/packages/adk-backend/package.json
@@ -13,9 +13,7 @@
   "dependencies": {
     "@coding-labs/shared": "workspace:*",
     "@google/adk": "^0.6.1",
-    "@google/adk-devtools": "^0.6.1"
-  },
-  "devDependencies": {
+    "@google/adk-devtools": "^0.6.1",
     "@types/node": "^22.13.0",
     "typescript": "^5.8.0"
   }

--- a/onchain-agents/coding-labs/pnpm-lock.yaml
+++ b/onchain-agents/coding-labs/pnpm-lock.yaml
@@ -50,7 +50,6 @@ importers:
       '@google/adk-devtools':
         specifier: ^0.6.1
         version: 0.6.1(dcncqlyal6hi2vohl23pozlfqe)
-    devDependencies:
       '@types/node':
         specifier: ^22.13.0
         version: 22.19.11


### PR DESCRIPTION
## Summary

- Move `typescript` and `@types/node` from `devDependencies` to `dependencies` in `packages/adk-backend/package.json`
- Regenerate `pnpm-lock.yaml` to reflect the dependency change

## Problem

The adk-backend container fails to load agents with "No agents found" because:

1. `typescript` is listed as a `devDependency` in `packages/adk-backend/package.json`
2. The Containerfile runner stage runs `pnpm install --frozen-lockfile --prod`, which excludes devDependencies
3. When `npx adk web ./agents --compile` tries to auto-compile `agent.ts`, TypeScript isn't available
4. The compilation silently fails, resulting in "No agents found"

## Fix

Move `typescript` and `@types/node` from `devDependencies` to `dependencies` so they are installed during the production build and available for agent compilation at runtime.

## Files Changed

- `onchain-agents/coding-labs/packages/adk-backend/package.json` — moved deps, removed empty `devDependencies` section
- `onchain-agents/coding-labs/pnpm-lock.yaml` — regenerated lockfile

Closes #40