### PR TITLE
fix(adk-backend): use pnpm exec instead of npx for binary resolution

### DIFF
--- a/onchain-agents/coding-labs/packages/adk-backend/Containerfile
+++ b/onchain-agents/coding-labs/packages/adk-backend/Containerfile
@@ -65,4 +65,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
 
 # Run - adk web serves both the API and the adk-web frontend
 WORKDIR /app/packages/adk-backend
-CMD npx adk web ./agents --port ${PORT:-8181} --host 0.0.0.0 --a2a
+CMD pnpm exec adk web ./agents --port ${PORT:-8181} --host 0.0.0.0 --a2a

--- a/onchain-agents/coding-labs/packages/adk-backend/package.json
+++ b/onchain-agents/coding-labs/packages/adk-backend/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "npx adk web ./agents --port 8181 --a2a",
+    "dev": "pnpm exec adk web ./agents --port 8181 --a2a",
     "build": "pnpm exec tsc",
-    "start": "npx adk web ./agents --port ${PORT:-8181} --a2a",
+    "start": "pnpm exec adk web ./agents --port ${PORT:-8181} --a2a",
     "clean": "rm -rf dist",
     "typecheck": "pnpm exec tsc --noEmit"
   },


### PR DESCRIPTION
## Summary

- Fix adk-backend container crash-loop caused by `npx` unable to resolve binaries in pnpm's `node_modules` layout
- Replace `npx` with `pnpm exec` in Containerfile CMD and package.json scripts (`dev`, `start`)

## Changes

| File | Change |
|------|--------|
| `packages/adk-backend/Containerfile` | CMD: `npx adk` → `pnpm exec adk` |
| `packages/adk-backend/package.json` | Scripts `dev` and `start`: `npx` → `pnpm exec` |

## Root Cause

The container installs packages with `pnpm` but the CMD used `npx` to run the `adk` binary. `npx` searches npm's flat `node_modules/.bin/` layout, but pnpm uses a content-addressable store with symlinks. This causes `npm error could not determine executable to run` on every container start.

## Testing

- Verified diff is minimal and correct (3 lines changed)
- No logic changes — purely a package manager command substitution

Closes #45