### PR TITLE
fix(adk-backend): override agent card URL for container and Cloud Run routing

### DIFF
--- a/onchain-agents/coding-labs/packages/adk-backend/agents/playground/agent.ts
+++ b/onchain-agents/coding-labs/packages/adk-backend/agents/playground/agent.ts
@@ -23,8 +23,11 @@ function getAgentBaseUrl(agentUrl: string): string {
 
 /**
  * Create RemoteA2AAgent instances for all enabled blockchain agents.
+ * Pre-fetches agent cards and overrides the url field with the known
+ * container/Cloud Run URL (the agent card's url field contains the
+ * bind address 0.0.0.0 which is not routable from other containers).
  */
-function createRemoteAgents(): RemoteA2AAgent[] {
+async function createRemoteAgents(): Promise<RemoteA2AAgent[]> {
   const config = loadConfigFile();
   const env = process.env.NODE_ENV || 'development';
   const enabledAgents = getEnabledAgents(config, env);
@@ -35,20 +38,39 @@ function createRemoteAgents(): RemoteA2AAgent[] {
     const baseUrl = getAgentBaseUrl(agent.url);
     console.log(`[adk-backend] Registering remote agent: ${agent.name} → ${baseUrl}`);
 
-    const remoteAgent = new RemoteA2AAgent({
-      name: agent.id.replace(/-/g, '_'), // ADK requires alphanumeric + underscore
-      description: agent.description,
-      agentCard: baseUrl,
-    });
+    try {
+      // Pre-fetch the agent card and override the url with the routable address.
+      // The agent card's url field contains the bind address (0.0.0.0) which is
+      // not reachable from other containers or Cloud Run services.
+      const cardUrl = `${baseUrl}/.well-known/agent-card.json`;
+      const response = await fetch(cardUrl);
 
-    remoteAgents.push(remoteAgent);
+      if (!response.ok) {
+        console.warn(`[adk-backend] Failed to fetch agent card from ${cardUrl}: ${response.status}, skipping ${agent.name}`);
+        continue;
+      }
+
+      const card = await response.json();
+      card.url = baseUrl; // Override with the known, routable URL
+
+      const remoteAgent = new RemoteA2AAgent({
+        name: agent.id.replace(/-/g, '_'), // ADK requires alphanumeric + underscore
+        description: card.description || agent.description,
+        agentCard: card, // Pass pre-loaded card with corrected URL
+      });
+
+      remoteAgents.push(remoteAgent);
+      console.log(`[adk-backend] ✓ Registered ${agent.name} (${card.skills?.length || 0} skills)`);
+    } catch (err) {
+      console.warn(`[adk-backend] ⚠ Could not reach ${agent.name} at ${baseUrl}, skipping: ${err instanceof Error ? err.message : err}`);
+    }
   }
 
   return remoteAgents;
 }
 
-// Create sub-agents from config
-const subAgents = createRemoteAgents();
+// Create sub-agents from config (async with top-level await)
+const subAgents = await createRemoteAgents();
 
 /**
  * Root agent - "Agent Playground"


### PR DESCRIPTION
## Summary

- Pre-fetch agent cards from `/.well-known/agent-card.json` and override the `url` field with the known routable base URL from config
- Fixes `RemoteA2AAgent` transfer failures caused by agent cards advertising `0.0.0.0` as their URL, which is not reachable across containers or Cloud Run services
- Adds graceful error handling — unreachable agents are skipped with a warning instead of crashing the root agent

## Changes

**`packages/adk-backend/agents/playground/agent.ts`**
- `createRemoteAgents()` → `async createRemoteAgents()` with `Promise<RemoteA2AAgent[]>` return type
- Pre-fetches each agent's card via `fetch()` and overrides `card.url` with the routable base URL
- Passes the pre-loaded card object (`agentCard: card`) instead of a URL string (`agentCard: baseUrl`)
- Uses `card.description` with fallback to config description for richer agent metadata
- Wraps each agent registration in try/catch for graceful degradation
- Uses top-level `await` (supported via `"type": "module"` in package.json)

## Root Cause

Blockchain agent cards contain `"url": "http://0.0.0.0:4002/"` — the bind address. ADK's `RemoteA2AAgent` uses this URL to send A2A JSON-RPC messages, but `0.0.0.0` is not routable from other containers. The fix overrides this with the container hostname (e.g., `http://sonic-agent:4002`) or Cloud Run URL from the config.

Closes #47