### PR TITLE
fix(shared): add LLM model factory to auto-detect Vertex AI provider from config.toml

### DIFF
--- a/onchain-agents/coding-labs/packages/midnight-agent/package.json
+++ b/onchain-agents/coding-labs/packages/midnight-agent/package.json
@@ -23,7 +23,6 @@
   ],
   "dependencies": {
     "@a2a-js/sdk": "^0.3.10",
-    "@ai-sdk/google-vertex": "^3.0.98",
     "@coding-labs/shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.27.0",
     "ai": "^5.0.0",

--- a/onchain-agents/coding-labs/packages/midnight-agent/src/genkit.ts
+++ b/onchain-agents/coding-labs/packages/midnight-agent/src/genkit.ts
@@ -1,40 +1,12 @@
 /**
- * LLM Configuration - AI SDK + Vertex AI Anthropic
+ * LLM Configuration for Midnight Agent
  *
- * Provides Claude models via Google Vertex AI using the AI SDK.
- * Authentication uses Google ADC (gcloud auth application-default login
- * or GOOGLE_APPLICATION_CREDENTIALS env var).
+ * Uses the shared model factory to create the correct LLM provider
+ * based on config.toml settings. For midnight-agent, config.toml assigns
+ * the "vertex-anthropic" provider (Claude via Vertex AI).
  */
 
-import { createVertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import type { LanguageModel } from 'ai';
+import { createModelForComponent } from '@coding-labs/shared/llm';
 
-// Read from component-specific env vars (generated from config.toml)
-const projectId =
-  process.env.MIDNIGHT_AGENT_LLM_PROJECT ||
-  process.env.GOOGLE_CLOUD_PROJECT ||
-  'kunal-scratch';
-
-const location =
-  process.env.MIDNIGHT_AGENT_LLM_LOCATION ||
-  process.env.GOOGLE_CLOUD_LOCATION ||
-  'global';
-
-const modelId = process.env.MIDNIGHT_AGENT_LLM_MODEL || 'claude-opus-4-5';
-
-// Create the Vertex Anthropic provider
-const vertexAnthropic = createVertexAnthropic({
-  project: projectId,
-  location: location,
-});
-
-// Export model instance for use in skills
-export const model: LanguageModel = vertexAnthropic(modelId);
-
-// Export config for logging
-export { projectId, location, modelId };
-
-console.log(`[midnight-agent] LLM initialized with Vertex AI Anthropic`);
-console.log(`[midnight-agent]   Project: ${projectId}`);
-console.log(`[midnight-agent]   Location: ${location}`);
-console.log(`[midnight-agent]   Model: ${modelId}`);
+// Create model from config.toml (respects env var overrides)
+export const model = createModelForComponent('midnight-agent');

--- a/onchain-agents/coding-labs/packages/security-agent/package.json
+++ b/onchain-agents/coding-labs/packages/security-agent/package.json
@@ -22,7 +22,6 @@
   ],
   "dependencies": {
     "@a2a-js/sdk": "^0.3.10",
-    "@ai-sdk/google-vertex": "^3.0.98",
     "@coding-labs/shared": "workspace:*",
     "ai": "^5.0.0",
     "cors": "^2.8.6",

--- a/onchain-agents/coding-labs/packages/security-agent/src/genkit.ts
+++ b/onchain-agents/coding-labs/packages/security-agent/src/genkit.ts
@@ -1,40 +1,12 @@
 /**
- * LLM Configuration - AI SDK + Vertex AI Anthropic
+ * LLM Configuration for Security Agent
  *
- * Provides Claude models via Google Vertex AI using the AI SDK.
- * Authentication uses Google ADC (gcloud auth application-default login
- * or GOOGLE_APPLICATION_CREDENTIALS env var).
+ * Uses the shared model factory to create the correct LLM provider
+ * based on config.toml settings. For security-agent, config.toml assigns
+ * the "vertex-anthropic" provider (Claude via Vertex AI).
  */
 
-import { createVertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import type { LanguageModel } from 'ai';
+import { createModelForComponent } from '@coding-labs/shared/llm';
 
-// Read from component-specific env vars (generated from config.toml)
-const projectId =
-  process.env.SECURITY_AGENT_LLM_PROJECT ||
-  process.env.GOOGLE_CLOUD_PROJECT ||
-  'kunal-scratch';
-
-const location =
-  process.env.SECURITY_AGENT_LLM_LOCATION ||
-  process.env.GOOGLE_CLOUD_LOCATION ||
-  'global';
-
-const modelId = process.env.SECURITY_AGENT_LLM_MODEL || 'claude-opus-4-5';
-
-// Create the Vertex Anthropic provider
-const vertexAnthropic = createVertexAnthropic({
-  project: projectId,
-  location: location,
-});
-
-// Export model instance for use in skills
-export const model: LanguageModel = vertexAnthropic(modelId);
-
-// Export config for logging
-export { projectId, location, modelId };
-
-console.log(`[security-agent] LLM initialized with Vertex AI Anthropic`);
-console.log(`[security-agent]   Project: ${projectId}`);
-console.log(`[security-agent]   Location: ${location}`);
-console.log(`[security-agent]   Model: ${modelId}`);
+// Create model from config.toml (respects env var overrides)
+export const model = createModelForComponent('security-agent');

--- a/onchain-agents/coding-labs/packages/shared/package.json
+++ b/onchain-agents/coding-labs/packages/shared/package.json
@@ -33,6 +33,8 @@
     "typecheck": "pnpm exec tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/google-vertex": "^3.0.98",
+    "ai": "^5.0.0",
     "smol-toml": "^1.3.1",
     "viem": "^2.21.0"
   },

--- a/onchain-agents/coding-labs/packages/shared/src/llm/factory.ts
+++ b/onchain-agents/coding-labs/packages/shared/src/llm/factory.ts
@@ -1,0 +1,69 @@
+/**
+ * LLM Model Factory
+ *
+ * Creates AI SDK LanguageModel instances based on config.toml settings.
+ * Auto-detects the correct Vertex AI provider (Google or Anthropic)
+ * from the provider type configuration.
+ */
+
+import { createVertex } from '@ai-sdk/google-vertex';
+import { createVertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
+import type { LanguageModel } from 'ai';
+import { loadConfigFile, getLLMConfig, getLLMConfigForComponent } from '../config/index.js';
+
+/**
+ * Convert a component name to an environment variable prefix.
+ * e.g., "sonic-agent" → "SONIC_AGENT"
+ */
+function toEnvPrefix(componentName: string): string {
+  return componentName.toUpperCase().replace(/-/g, '_');
+}
+
+/**
+ * Create a LanguageModel for a named component using config.toml settings.
+ *
+ * Resolution order:
+ *   1. config.toml [default.llm.components] → provider mapping
+ *   2. config.toml [default.llm.providers.<name>] → provider config (type, project, location, model)
+ *   3. Environment variables override (e.g., SONIC_AGENT_LLM_MODEL, SONIC_AGENT_LLM_PROJECT)
+ *
+ * @param componentName - The component name as defined in config.toml (e.g., "sonic-agent")
+ * @returns A configured LanguageModel instance
+ */
+export function createModelForComponent(componentName: string): LanguageModel {
+  const config = loadConfigFile();
+  const llmConfig = getLLMConfig(config);
+  const providerConfig = getLLMConfigForComponent(llmConfig, componentName);
+
+  if (!providerConfig) {
+    throw new Error(
+      `No LLM provider configured for component "${componentName}". ` +
+      `Check config.toml [default.llm.components] and [default.llm.providers].`
+    );
+  }
+
+  const prefix = toEnvPrefix(componentName);
+
+  // Environment variable overrides take precedence
+  const project = process.env[`${prefix}_LLM_PROJECT`] || process.env.GOOGLE_CLOUD_PROJECT || providerConfig.project;
+  const location = process.env[`${prefix}_LLM_LOCATION`] || process.env.GOOGLE_CLOUD_LOCATION || providerConfig.location;
+  const model = process.env[`${prefix}_LLM_MODEL`] || providerConfig.model;
+
+  console.log(`[shared/llm] Creating model for ${componentName}: type=${providerConfig.type}, model=${model}, project=${project}, location=${location}`);
+
+  switch (providerConfig.type) {
+    case 'vertex': {
+      const vertex = createVertex({ project, location });
+      return vertex(model);
+    }
+    case 'vertex-anthropic': {
+      const anthropic = createVertexAnthropic({ project, location });
+      return anthropic(model);
+    }
+    default:
+      throw new Error(
+        `Unknown LLM provider type "${providerConfig.type}" for component "${componentName}". ` +
+        `Supported types: "vertex", "vertex-anthropic"`
+      );
+  }
+}

--- a/onchain-agents/coding-labs/packages/shared/src/llm/index.ts
+++ b/onchain-agents/coding-labs/packages/shared/src/llm/index.ts
@@ -1,1 +1,2 @@
 export * from './types.js';
+export { createModelForComponent } from './factory.js';

--- a/onchain-agents/coding-labs/packages/somnia-agent/package.json
+++ b/onchain-agents/coding-labs/packages/somnia-agent/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@a2a-js/sdk": "^0.3.10",
     "@coding-labs/shared": "workspace:*",
-    "@ai-sdk/google-vertex": "^3.0.98",
     "ai": "^5.0.0",
     "express": "^4.21.0",
     "uuid": "^11.0.0",

--- a/onchain-agents/coding-labs/packages/somnia-agent/src/genkit.ts
+++ b/onchain-agents/coding-labs/packages/somnia-agent/src/genkit.ts
@@ -1,41 +1,12 @@
 /**
- * LLM Configuration - AI SDK + Vertex AI Anthropic
+ * LLM Configuration for Somnia Agent
  *
- * Provides Claude models via Google Vertex AI using the AI SDK.
- * Authentication uses Google ADC (gcloud auth application-default login
- * or GOOGLE_APPLICATION_CREDENTIALS env var).
+ * Uses the shared model factory to create the correct LLM provider
+ * based on config.toml settings. For somnia-agent, config.toml assigns
+ * the "vertex-anthropic" provider (Claude via Vertex AI).
  */
 
-import { createVertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import type { LanguageModel } from 'ai';
+import { createModelForComponent } from '@coding-labs/shared/llm';
 
-// Read from component-specific env vars (generated from config.toml)
-// Falls back to generic env vars for backward compatibility
-const projectId =
-  process.env.SOMNIA_AGENT_LLM_PROJECT ||
-  process.env.GOOGLE_CLOUD_PROJECT ||
-  'kunal-scratch';
-
-const location =
-  process.env.SOMNIA_AGENT_LLM_LOCATION ||
-  process.env.GOOGLE_CLOUD_LOCATION ||
-  'global';
-
-const modelId = process.env.SOMNIA_AGENT_LLM_MODEL || 'claude-opus-4-5';
-
-// Create the Vertex Anthropic provider
-const vertexAnthropic = createVertexAnthropic({
-  project: projectId,
-  location: location,
-});
-
-// Export model instance for use in skills
-export const model: LanguageModel = vertexAnthropic(modelId);
-
-// Export config for logging
-export { projectId, location, modelId };
-
-console.log(`[somnia-agent] LLM initialized with Vertex AI Anthropic`);
-console.log(`[somnia-agent]   Project: ${projectId}`);
-console.log(`[somnia-agent]   Location: ${location}`);
-console.log(`[somnia-agent]   Model: ${modelId}`);
+// Create model from config.toml (respects env var overrides)
+export const model = createModelForComponent('somnia-agent');

--- a/onchain-agents/coding-labs/packages/sonic-agent/package.json
+++ b/onchain-agents/coding-labs/packages/sonic-agent/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.10",
-    "@ai-sdk/google-vertex": "^3.0.98",
     "@coding-labs/shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "ai": "^5.0.0",

--- a/onchain-agents/coding-labs/packages/sonic-agent/src/genkit.ts
+++ b/onchain-agents/coding-labs/packages/sonic-agent/src/genkit.ts
@@ -1,13 +1,12 @@
 /**
  * LLM Configuration for Sonic Agent
  *
- * Uses Vertex AI with Claude for code generation.
- * Authentication uses Google ADC (gcloud auth application-default login
- * or GOOGLE_APPLICATION_CREDENTIALS env var).
+ * Uses the shared model factory to create the correct LLM provider
+ * based on config.toml settings. For sonic-agent, config.toml assigns
+ * the "vertex-gemini" provider (Gemini via Vertex AI).
  */
 
-import { createVertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import type { LanguageModel } from 'ai';
+import { createModelForComponent } from '@coding-labs/shared/llm';
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -16,36 +15,8 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Read from component-specific env vars (generated from config.toml)
-// Falls back to generic env vars for backward compatibility
-const projectId =
-  process.env.SONIC_AGENT_LLM_PROJECT ||
-  process.env.GOOGLE_CLOUD_PROJECT ||
-  'kunal-scratch';
-
-const location =
-  process.env.SONIC_AGENT_LLM_LOCATION ||
-  process.env.GOOGLE_CLOUD_LOCATION ||
-  'global';
-
-const modelId = process.env.SONIC_AGENT_LLM_MODEL || 'claude-opus-4-5';
-
-// Create the Vertex Anthropic provider
-const vertexAnthropic = createVertexAnthropic({
-  project: projectId,
-  location: location,
-});
-
-// Export model instance for use in skills
-export const model: LanguageModel = vertexAnthropic(modelId);
-
-// Export config for logging
-export { projectId, location, modelId };
-
-console.log(`[SonicAgent] LLM initialized with Vertex AI Anthropic`);
-console.log(`[SonicAgent]   Project: ${projectId}`);
-console.log(`[SonicAgent]   Location: ${location}`);
-console.log(`[SonicAgent]   Model: ${modelId}`);
+// Create model from config.toml (respects env var overrides)
+export const model = createModelForComponent('sonic-agent');
 
 /**
  * Load the SKILLS.md file as context for the LLM.

--- a/onchain-agents/coding-labs/pnpm-lock.yaml
+++ b/onchain-agents/coding-labs/pnpm-lock.yaml
@@ -103,9 +103,6 @@ importers:
       '@a2a-js/sdk':
         specifier: ^0.3.10
         version: 0.3.10(@grpc/grpc-js@1.14.3)(express@4.22.1)
-      '@ai-sdk/google-vertex':
-        specifier: ^3.0.98
-        version: 3.0.104(zod@4.3.6)
       '@coding-labs/shared':
         specifier: workspace:*
         version: link:../shared
@@ -205,9 +202,6 @@ importers:
       '@a2a-js/sdk':
         specifier: ^0.3.10
         version: 0.3.10(@grpc/grpc-js@1.14.3)(express@4.22.1)
-      '@ai-sdk/google-vertex':
-        specifier: ^3.0.98
-        version: 3.0.104(zod@4.3.6)
       '@coding-labs/shared':
         specifier: workspace:*
         version: link:../shared
@@ -245,6 +239,12 @@ importers:
 
   packages/shared:
     dependencies:
+      '@ai-sdk/google-vertex':
+        specifier: ^3.0.98
+        version: 3.0.104(zod@4.3.6)
+      ai:
+        specifier: ^5.0.0
+        version: 5.0.133(zod@4.3.6)
       smol-toml:
         specifier: ^1.3.1
         version: 1.6.0
@@ -264,9 +264,6 @@ importers:
       '@a2a-js/sdk':
         specifier: ^0.3.10
         version: 0.3.10(@grpc/grpc-js@1.14.3)(express@4.22.1)
-      '@ai-sdk/google-vertex':
-        specifier: ^3.0.98
-        version: 3.0.104(zod@4.3.6)
       '@coding-labs/shared':
         specifier: workspace:*
         version: link:../shared
@@ -304,9 +301,6 @@ importers:
       '@a2a-js/sdk':
         specifier: ^0.3.10
         version: 0.3.10(@grpc/grpc-js@1.14.3)(express@4.22.1)
-      '@ai-sdk/google-vertex':
-        specifier: ^3.0.98
-        version: 3.0.104(zod@4.3.6)
       '@coding-labs/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
## Summary

- **Add shared `createModelForComponent()` factory** in `packages/shared/src/llm/factory.ts` that reads config.toml to auto-detect the correct Vertex AI provider (Google Gemini vs Anthropic Claude) based on the `type` field
- **Update all 4 LLM-powered agents** (sonic, somnia, midnight, security) to use the shared factory instead of hardcoded `createVertexAnthropic`, fixing the sonic-agent 404 caused by provider/model mismatch
- **Centralize AI SDK dependency** (`@ai-sdk/google-vertex`) in the shared package, removing it from individual agent package.json files

## Problem

All 4 agents hardcoded `createVertexAnthropic` in their `genkit.ts`, ignoring `config.toml` entirely. For sonic-agent, `config.toml` assigns `vertex-gemini` (gemini-2.0-flash) but the code forced the Anthropic provider, causing a 404 on code generation requests.

## Changes

### New file
- `packages/shared/src/llm/factory.ts` — Model factory that resolves provider from config.toml with env var overrides

### Modified files
- `packages/shared/src/llm/index.ts` — Export `createModelForComponent`
- `packages/shared/package.json` — Add `@ai-sdk/google-vertex` and `ai` dependencies
- `packages/sonic-agent/src/genkit.ts` — Use shared factory (preserves `loadSkillsContext` and `getSolidityGenSystemPrompt`)
- `packages/somnia-agent/src/genkit.ts` — Use shared factory
- `packages/midnight-agent/src/genkit.ts` — Use shared factory
- `packages/security-agent/src/genkit.ts` — Use shared factory
- Agent `package.json` files — Remove `@ai-sdk/google-vertex` (now provided by shared)
- `pnpm-lock.yaml` — Updated lockfile

## Testing

- All 5 packages build successfully (`pnpm build` for shared + 4 agents)
- Existing tests pass (3 pre-existing failures in midnight-mcp are unrelated version string mismatches)

Closes #49