### PR TITLE
feat(adk-backend): align adk-web UI with Gemini branding and hide dev-only features

### DIFF
--- a/onchain-agents/coding-labs/packages/adk-backend/Containerfile
+++ b/onchain-agents/coding-labs/packages/adk-backend/Containerfile
@@ -47,6 +47,11 @@ COPY --from=builder /app/packages/adk-backend/agents packages/adk-backend/agents
 # Install production dependencies only
 RUN pnpm install --frozen-lockfile --prod
 
+# Apply Agent Playground branding to bundled adk-web UI
+COPY --from=builder /app/packages/adk-backend/scripts packages/adk-backend/scripts/
+COPY --from=builder /app/packages/adk-backend/assets packages/adk-backend/assets/
+RUN cd /app && bash packages/adk-backend/scripts/customize-ui.sh
+
 # Set environment
 ENV NODE_ENV=production
 # PORT is set by Cloud Run, default to 8181 for local development

--- a/onchain-agents/coding-labs/packages/adk-backend/assets/favicon.svg
+++ b/onchain-agents/coding-labs/packages/adk-backend/assets/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4285F4"/>
+      <stop offset="50%" style="stop-color:#A370F0"/>
+      <stop offset="100%" style="stop-color:#F87171"/>
+    </linearGradient>
+  </defs>
+  <path d="M16 2 L18.5 12.5 L28 16 L18.5 19.5 L16 30 L13.5 19.5 L4 16 L13.5 12.5 Z" fill="url(#g)"/>
+</svg>

--- a/onchain-agents/coding-labs/packages/adk-backend/assets/logo.svg
+++ b/onchain-agents/coding-labs/packages/adk-backend/assets/logo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="sparkle" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4285F4"/>
+      <stop offset="33%" style="stop-color:#A370F0"/>
+      <stop offset="66%" style="stop-color:#F87171"/>
+      <stop offset="100%" style="stop-color:#FBBC05"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="64" fill="#131314"/>
+  <path d="M256 96 L272 208 L384 256 L272 304 L256 416 L240 304 L128 256 L240 208 Z" fill="url(#sparkle)" opacity="0.9"/>
+  <text x="256" y="480" text-anchor="middle" fill="#E8EAED" font-family="Google Sans, sans-serif" font-size="36" font-weight="500">Agent Playground</text>
+</svg>

--- a/onchain-agents/coding-labs/packages/adk-backend/package.json
+++ b/onchain-agents/coding-labs/packages/adk-backend/package.json
@@ -8,7 +8,8 @@
     "build": "pnpm exec tsc",
     "start": "pnpm exec adk web ./agents --port ${PORT:-8181} --a2a",
     "clean": "rm -rf dist",
-    "typecheck": "pnpm exec tsc --noEmit"
+    "typecheck": "pnpm exec tsc --noEmit",
+    "postinstall": "bash scripts/customize-ui.sh || true"
   },
   "dependencies": {
     "@coding-labs/shared": "workspace:*",

--- a/onchain-agents/coding-labs/packages/adk-backend/scripts/customize-ui.sh
+++ b/onchain-agents/coding-labs/packages/adk-backend/scripts/customize-ui.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Customize adk-web UI bundled inside @google/adk-devtools
+# This script patches the bundled dev-ui files with Agent Playground branding
+# and Gemini-aligned styles. Run after pnpm install.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PACKAGE_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Find the bundled browser directory
+BROWSER_DIR="${PACKAGE_DIR}/node_modules/@google/adk-devtools/dist/browser"
+
+if [ ! -d "$BROWSER_DIR" ]; then
+  echo "[customize-ui] Browser directory not found at ${BROWSER_DIR}, skipping"
+  exit 0
+fi
+
+echo "[customize-ui] Customizing adk-web UI at ${BROWSER_DIR}..."
+
+# --- 1. Patch index.html ---
+INDEX_HTML="${BROWSER_DIR}/index.html"
+
+if [ -f "$INDEX_HTML" ]; then
+  # Replace page title
+  sed -i 's|<title>[^<]*</title>|<title>Agent Playground \| Google Cloud</title>|g' "$INDEX_HTML"
+
+  # Inject Gemini branding CSS and feature flag overrides before </head>
+  # Only inject if not already present (idempotent)
+  if ! grep -q "agent-playground-branding" "$INDEX_HTML"; then
+    sed -i '/<\/head>/i \
+<!-- Agent Playground Branding -->\
+<style id="agent-playground-branding">\
+  /* === Gemini Sparkle Gradients === */\
+  html.dark-theme {\
+    /* Canvas/builder header title gradient - Gemini sparkle colors */\
+    --builder-canvas-header-title-gradient: linear-gradient(135deg, #4285F4, #A370F0, #F87171, #FBBC05);\
+    --builder-canvas-container-background: linear-gradient(135deg, #0c0b0f 0%, #131314 50%, #0f1218 100%);\
+    --builder-canvas-node-badge-background: linear-gradient(135deg, rgba(66, 133, 244, 0.2), rgba(163, 112, 240, 0.3));\
+    --builder-canvas-add-btn-shadow: 0 4px 12px rgba(66, 133, 244, 0.35);\
+    \
+    /* Gemini purple accent on active/focused elements */\
+    --chat-panel-bot-message-focus-within-message-card-border-color: #A370F0;\
+    --event-tab-event-list-active-indicator-color: #A370F0;\
+    \
+    /* Subtle blue-purple tint on surfaces (vs pure gray) */\
+    --chat-side-drawer-background-color: #18161e;\
+    --chat-toolbar-background-color: #1a1820;\
+    --side-panel-details-panel-container-background-color: #1e1c26;\
+  }\
+  \
+  /* === Hide elements for clean Agent Playground UX === */\
+  /* Hide Dev UI disclaimer banner */\
+  .developer-disclaimer, [class*="disclaimer"] {\
+    display: none !important;\
+  }\
+  /* Hide eval tab (endpoints return 501 in adk-js) */\
+  [aria-label="Eval"], mat-tab[aria-label="Eval"] {\
+    display: none !important;\
+  }\
+  /* Hide bidi streaming controls (not implemented in adk-js) */\
+  .bidi-streaming-controls, [class*="bidi"] {\
+    display: none !important;\
+  }\
+</style>' "$INDEX_HTML"
+    echo "[customize-ui] ✓ Injected Gemini branding CSS"
+  else
+    echo "[customize-ui] Branding CSS already present, skipping"
+  fi
+fi
+
+# --- 2. Replace favicon ---
+CUSTOM_FAVICON="${PACKAGE_DIR}/assets/favicon.svg"
+if [ -f "$CUSTOM_FAVICON" ]; then
+  cp "$CUSTOM_FAVICON" "${BROWSER_DIR}/adk_favicon.svg"
+  echo "[customize-ui] ✓ Replaced favicon"
+fi
+
+# --- 3. Replace logo ---
+CUSTOM_LOGO="${PACKAGE_DIR}/assets/logo.svg"
+if [ -f "$CUSTOM_LOGO" ]; then
+  mkdir -p "${BROWSER_DIR}/assets"
+  cp "$CUSTOM_LOGO" "${BROWSER_DIR}/assets/ADK-512-color.svg"
+  echo "[customize-ui] ✓ Replaced logo"
+fi
+
+echo "[customize-ui] Done!"


### PR DESCRIPTION
## Summary

- Add Agent Playground branding to the bundled adk-web UI via CSS injection and asset replacement (no fork required)
- Inject Gemini sparkle gradients, purple accents, and blue-purple tinted dark theme surfaces
- Hide dev-only UI elements: disclaimer banner, Eval tab (501 in adk-js), bidi streaming controls

## Changes

### New Files
- `packages/adk-backend/scripts/customize-ui.sh` — Idempotent post-install script that patches `@google/adk-devtools/dist/browser/` with branding
- `packages/adk-backend/assets/favicon.svg` — Gemini sparkle favicon (blue → purple → pink gradient)
- `packages/adk-backend/assets/logo.svg` — Agent Playground logo with Gemini sparkle motif

### Modified Files
- `packages/adk-backend/package.json` — Added `postinstall` hook to run branding script automatically
- `packages/adk-backend/Containerfile` — Added COPY + RUN steps to apply branding in production image

## Design References
- [Gemini AI Visual Design](https://design.google/library/gemini-ai-visual-design)
- CSS custom properties target adk-web's dark theme variables
- Gradient: `#4285F4` → `#A370F0` → `#F87171` → `#FBBC05` (Google Blue → Purple → Pink → Yellow)

## Testing
- Script is idempotent (grep guard prevents double injection)
- Gracefully skips if `node_modules/@google/adk-devtools/dist/browser` doesn't exist
- Works in both local dev (`pnpm install` triggers postinstall) and container builds

Closes #52