### PR TITLE
feat: migrate opencode-web to LB + IAP + GCIP magic-link (v1) (#60)

### DIFF
--- a/onchain-agents/coding-labs/.context.md
+++ b/onchain-agents/coding-labs/.context.md
@@ -257,6 +257,93 @@ Sonic is a high-performance EVM-compatible L1 (rebranded from Fantom):
 - **Full end-to-end test via OpenCode web UI** - Test generate → compile → deploy → call → query-state with session persistence
 - **Add session persistence** - Current in-memory session state is lost on container restart
 
+### 2026-04-24 (session 25)
+- **Migrated from Cloud Run direct IAP to LB + IAP + GCIP agent flow (issue #60):**
+  - Replaces direct IAP flag (`gcloud beta run deploy --iap`) on `opencode-web`
+    with External HTTPS LB + IAP enabled at the LB **backend service** layer
+    using GCIP federation via the "agent flow" pattern
+    (`gcipSettings.tenantIds: ["_<project_number>"]`).
+  - Magic-link email sign-in only (v1 scope; OAuth providers — GitHub,
+    Google, Apple, Microsoft — deferred to v2).
+  - Single subdomain `dcoder.<base_domain>` with path-based URL-map routing:
+    - `/login*`     + `/__/auth/*` → `opencode-login-backend` (no IAP)
+    - `/*` (default)              → `opencode-web-backend` (IAP enabled)
+  - Cross-project Cloud DNS managed zone (DNS lives in a separate Argolis
+    project; Cloud Build SA needs `roles/dns.recordSetEditor` on it).
+- **Argolis-specific finding documented:**
+  - The IAP `gcipSettings.tenantIds` field accepts an undocumented value
+    pattern `["_<project_number>"]` that activates GCIP **agent flow** —
+    project-scoped GCIP without requiring multi-tenancy. Multi-tenant mode is
+    gated at the Argolis org level but is NOT needed for this architecture.
+  - Empirically validated by pilot session
+    `/tmp/pilot-gcip-orgpolicy-220993ee` (referenced in issue #60 v1 spec).
+- **Naming reconciliation (issue #61) executed inline:**
+  - `cloudbuild.yaml` now builds and deploys the service as `opencode-web`
+    (matches live Cloud Run state). The package directory remains
+    `packages/adk-backend/` for now — Containerfile path is unchanged.
+- **Files Modified:**
+  - `config.toml` — added `[default.dns]` block with placeholders
+    (`<DNS_PROJECT_ID>`, `<ZONE_NAME>`, `<BASE_DOMAIN>`); added
+    `path_prefix(es)` and `iap_enabled` fields to new
+    `[default.services.opencode-web]` and `[default.services.opencode-login]`
+    blocks.
+  - `cloudbuild.yaml` — dropped `--iap`, dropped the `setup-iap` step,
+    switched both `opencode-web` and `opencode-login` to
+    `--ingress=internal-and-cloud-load-balancing`, added Firebase env vars
+    (via `_FIREBASE_API_KEY` / `_FIREBASE_AUTH_DOMAIN` substitutions),
+    renamed all `adk-backend` build/push/deploy step IDs and image names to
+    `opencode-web`. Containerfile path stays `packages/adk-backend/`.
+  - `scripts/cloud.sh` — replaced `cmd_sync_users` with `cmd_sync_iap_users`
+    (now binds users on the `opencode-web-backend` backend service IAP IAM,
+    not Cloud Run direct IAP); added `cmd_setup_dns`, `cmd_setup_lb`,
+    `cmd_setup_gcip_magiclink`, `cmd_teardown_lb`; added `_dns_field` and
+    `_require_dns_config` helpers reused across all DNS-aware commands.
+  - `Makefile` — replaced `cloud-sync-users` target with `cloud-sync-iap-users`;
+    added `cloud-setup-dns`, `cloud-setup-lb`, `cloud-setup-gcip-magiclink`,
+    `cloud-teardown-lb`.
+  - `packages/opencode-login/server.js` — extended `/config` endpoint to also
+    return `firebase: { apiKey, authDomain, projectId }`; added explicit
+    `/login` route declared before the static middleware.
+  - `packages/opencode-login/public/index.html` — replaced the single "Sign
+    in with Google" anchor with email input + send-link button + state
+    container; added a Firebase JS SDK module script that calls
+    `sendSignInLinkToEmail` against the `actionCodeSettings.url =
+    window.location.origin + '/__/auth/handler'`.
+  - `packages/opencode-login/public/styles.css` — added magic-link UI styles
+    (email input, error/hint text, secondary "Send another link" button)
+    integrated with the existing dark-theme design system.
+  - `compose.yaml` — added Firebase env vars to opencode-login service;
+    added optional `firebase-auth-emulator` service under
+    `profiles: ['emulator']`.
+  - `README.md` — updated the Detailed Architecture diagram to show the LB +
+    URL-map routing + GCIP magic-link flow; expanded the Cloud make-target
+    table with the new targets; added Firebase env-var rows; added a "Custom
+    domain & magic-link auth" section pointing to `gcip-magiclink-setup.md`.
+  - `packages/opencode-login/README.md` — rewrote the architecture diagram
+    for the LB-fronted flow; updated env-vars table.
+- **New Files:**
+  - `packages/opencode-login/public/__/auth/handler.html` — Firebase
+    email-link return handler. Calls `signInWithEmailLink` and redirects to
+    `continueUri` / `state` / `/`.
+  - `gcip-magiclink-setup.md` — top-level Phase 0 → Phase 5 setup walkthrough
+    covering DNS prerequisites, cross-project IAM, `make` target sequence,
+    and the manual one-time `gcloud beta iap settings set` command for the
+    gcipSettings YAML.
+- **Resolves:** GitHub issues #60 (migration) and #61 (naming reconciliation).
+- **Supersedes:** GitHub issue #59 (original cross-project Firebase plan, closed).
+- **Open TODOs surfaced during implementation:**
+  - The exact IAP+GCIP redirect-back contract (whether the simple
+    `window.location.href = continueUri` pattern is sufficient, or whether
+    additional code is needed to POST the ID token to an IAP-specific
+    endpoint or rely on Firebase JS SDK's session-cookie behaviour) is
+    documented inline in `handler.html` and in `gcip-magiclink-setup.md`
+    "Open issues" — the simple pattern is implemented first; if the
+    operator finds it insufficient during verification, the handler can be
+    extended.
+  - `cmd_setup_lb` enables IAP on `opencode-web-backend` but does NOT apply
+    the gcipSettings YAML (Phase 4 is still manual). A future enhancement is
+    to make this fully scripted once the apiKey is captured into config.
+
 ### 2026-02-19 (session 24)
 - **Fixed Binary Artifact Encoding Bug in Midnight Deploy Pipeline:**
   - **Root Cause:** Binary ZK key files (`.prover`, `.verifier`, `.bzkir`) were being written as base64 TEXT instead of being decoded to binary

--- a/onchain-agents/coding-labs/Makefile
+++ b/onchain-agents/coding-labs/Makefile
@@ -6,6 +6,8 @@
         container-clean container-build container-run container-stop container-logs \
         up down rebuild logs \
         cloud-setup cloud-deploy cloud-status cloud-urls cloud-logs cloud-delete \
+        cloud-setup-dns cloud-setup-lb cloud-setup-gcip-magiclink \
+        cloud-sync-iap-users cloud-teardown-lb \
         config health send
 
 .DEFAULT_GOAL := help
@@ -82,8 +84,20 @@ cloud-logs: ## View Cloud Run logs (SVC=service-name)
 cloud-delete: ## Delete all Cloud Run services
 	@./scripts/cloud.sh delete
 
-cloud-sync-users: ## Sync IAP allowed users from config.toml
-	@./scripts/cloud.sh sync-users
+cloud-setup-dns: ## Set up cross-project DNS A record from config.toml
+	@./scripts/cloud.sh setup-dns
+
+cloud-setup-lb: ## Provision LB resources (URL map, backend services, NEGs, cert)
+	@./scripts/cloud.sh setup-lb
+
+cloud-setup-gcip-magiclink: ## Enable GCIP email-link sign-in in this project
+	@./scripts/cloud.sh setup-gcip-magiclink
+
+cloud-sync-iap-users: ## Sync IAP allowed_users from config.toml to opencode-web-backend
+	@./scripts/cloud.sh sync-iap-users
+
+cloud-teardown-lb: ## DESTRUCTIVE: tear down LB resources
+	@./scripts/cloud.sh teardown-lb
 
 # =============================================================================
 # UTILITIES

--- a/onchain-agents/coding-labs/README.md
+++ b/onchain-agents/coding-labs/README.md
@@ -29,21 +29,41 @@ Coding Labs provides AI agents specialized for blockchain development. Each agen
 
 **Detailed Architecture**
 
+The deployment fronts two Cloud Run services with a single External HTTPS
+Load Balancer at `dcoder.<base_domain>`. URL-map path routing sends
+`/login` and `/__/auth/*` to `opencode-login` (the magic-link sign-in UI,
+no IAP) and everything else to `opencode-web` (IAP at the LB backend
+service via gcipSettings agent flow). See `gcip-magiclink-setup.md` for
+details and issue #60 for rationale.
+
 ```
-┌──────────────────────┐         ┌─────────────────────────────────────────────┐
-│   opencode-login     │         │              opencode-web                   │
-│                      │         │  ┌─────────────────────────────────────┐    │
-│                      │         │  │            OpenCode Web             │    │
-│   dCoder Landing     │  ──→    │  │       (Primary User Interface)      │    │
-│   "Sign in with      │  click  │  │                                     │    │
-│    Google" button    │         │  │  - Browser-based coding session     │    │
-│                      │         │  │  - Wallet connection (MetaMask)     │    │
-│   (Public)           │         │  │  - A2A Client integrated            │    │
-│                      │         │  │  - Routes to chain agents           │    │
-└──────────────────────┘         │  └──────────────────┬──────────────────┘    │
-                                 │    (IAP Protected)  │                       │
-                                 └─────────────────────┼───────────────────────┘
-                                                       │ A2A Protocol (HTTP+JSON)
+                       https://dcoder.<base_domain>
+                                    │
+              ┌─────────────────────┴─────────────────────┐
+              │  External HTTPS LB + URL map              │
+              │   /login*    + /__/auth/* → opencode-login│
+              │   /*  (default)           → opencode-web  │
+              │   IAP (gcipSettings agent flow) on        │
+              │       opencode-web-backend only           │
+              └─────────────────┬─────────┬───────────────┘
+                                │         │
+              ┌─────────────────┘         └─────────────────────────┐
+              ▼                                                     ▼
+┌──────────────────────┐                ┌─────────────────────────────────────────────┐
+│   opencode-login     │                │              opencode-web                   │
+│                      │                │  ┌─────────────────────────────────────┐    │
+│  Magic-link UI       │ Firebase JS    │  │            OpenCode Web             │    │
+│  /login              │ ──email link── │  │       (Primary User Interface)      │    │
+│  /__/auth/handler    │   ◀──────────  │  │                                     │    │
+│                      │                │  │  - Browser-based coding session     │    │
+│  GCIP "agent flow"   │                │  │  - Wallet connection (MetaMask)     │    │
+│  tenantIds:          │                │  │  - A2A Client integrated            │    │
+│  ["_<project_num>"]  │                │  │  - Routes to chain agents           │    │
+│  (LB-only ingress,   │                │  └──────────────────┬──────────────────┘    │
+│   no IAP)            │                │    (LB-only ingress;│                       │
+└──────────────────────┘                │     IAP at backend) │                       │
+                                        └─────────────────────┼───────────────────────┘
+                                                              │ A2A Protocol (HTTP+JSON)
        ┌──────────────┬──────────────┬─────────────────┼──────────────┬──────────────┬──────────────────┐
        ▼              ▼              ▼                  ▼              ▼              ▼                  ▼
 ┌─────────────────┐ ┌─────────────────┐ ┌──────────────────┐ ┌─────────────────┐ ┌──────────────────┐ ┌─────────────────┐
@@ -328,8 +348,17 @@ make help  # Show all available targets
 #### Cloud
 | Target | Description |
 |--------|-------------|
-| `cloud-build` | Build for Cloud Run (stub) |
-| `cloud-deploy` | Deploy to Cloud Run (stub) |
+| `cloud-setup` | One-time cloud infrastructure setup |
+| `cloud-deploy` | Deploy all services to Cloud Run |
+| `cloud-status` | Show Cloud Run service status |
+| `cloud-urls` | Print Cloud Run service URLs |
+| `cloud-logs SVC=<name>` | View Cloud Run logs |
+| `cloud-delete` | Delete all Cloud Run services |
+| `cloud-setup-dns` | Create cross-project DNS A record from `config.toml` |
+| `cloud-setup-lb` | Provision LB resources (NEGs, backend services, URL map, cert) |
+| `cloud-setup-gcip-magiclink` | Enable GCIP email-link sign-in |
+| `cloud-sync-iap-users` | Sync IAP allowed users from `config.toml` to `opencode-web-backend` |
+| `cloud-teardown-lb` | DESTRUCTIVE: tear down LB resources |
 
 #### Utilities
 | Target | Description |
@@ -417,6 +446,20 @@ describe('somniaAgentCard', () => {
 | `SOMNIA_AGENT_HOST` | `localhost` | Agent host |
 | `GOOGLE_CLOUD_PROJECT` | `kunal-scratch` | GCP project for Vertex AI |
 | `GOOGLE_CLOUD_LOCATION` | `global` | GCP region |
+| `FIREBASE_API_KEY` | _(unset)_ | Public Firebase Web API key (browser-safe). Required by `opencode-login` to render the magic-link sign-in UI. See `gcip-magiclink-setup.md`. |
+| `FIREBASE_AUTH_DOMAIN` | _(unset)_ | Firebase auth domain, typically `<project>.firebaseapp.com`. Public, browser-safe. |
+| `FIREBASE_PROJECT_ID` | `kunal-scratch` | GCP project ID hosting GCIP. |
+
+### Custom domain & magic-link auth
+
+The production deployment is fronted by an External HTTPS Load Balancer at
+`dcoder.<base_domain>` with IAP + GCIP "agent flow" + magic-link email
+sign-in (issue #60). Path-based routing on the URL map sends `/login*` and
+`/__/auth/*` to a public sign-in service (`opencode-login`) and everything
+else to the IAP-protected app backend (`opencode-web`).
+
+For one-time bootstrap (DNS, SSL cert, LB resources, GCIP enable, IAP user
+sync), see [`gcip-magiclink-setup.md`](./gcip-magiclink-setup.md).
 
 ### Centralized Configuration
 

--- a/onchain-agents/coding-labs/cloudbuild.yaml
+++ b/onchain-agents/coding-labs/cloudbuild.yaml
@@ -9,14 +9,27 @@
 #   5. Deploy midnight-mcp (depends on Midnight infrastructure URLs)
 #   6. Deploy somnia-agent (with AGENT_REGISTRY_URL)
 #   7. Deploy midnight-agent (with AGENT_REGISTRY_URL + MIDNIGHT_MCP_URL)
-#   8. Deploy opencode-login (public landing page)
-#   9. Deploy opencode-web (with all agent URLs + LOGIN_PAGE_URL, IAP protected)
+#   8. Deploy opencode-login (magic-link sign-in UI; LB-only ingress, public)
+#   9. Deploy opencode-web (with all agent URLs + LOGIN_PAGE_URL, LB-only)
 #
 # Services:
 #   - midnight-node, midnight-indexer, midnight-proof-server: Public (Midnight infra)
 #   - agent-registry, somnia-agent, midnight-agent, midnight-mcp: Public (no auth)
-#   - opencode-login: Public (landing page)
-#   - opencode-web: IAP protected (requires Google sign-in)
+#   - opencode-login: LB-only, no auth (renders the magic-link sign-in page)
+#   - opencode-web:   LB-only, IAP via gcipSettings agent flow at backend
+#                     service layer (NOT direct Cloud Run --iap)
+#
+# Authentication architecture (issue #60):
+#   External Application LB + IAP at LB backend service + GCIP "agent flow"
+#   + magic-link email sign-in. See gcip-magiclink-setup.md.
+#
+#   The LB resources, IAP enablement, gcipSettings YAML, and IAP IAM bindings
+#   are NOT provisioned by this pipeline. They are managed by:
+#     make cloud-setup-dns
+#     make cloud-setup-lb
+#     make cloud-setup-gcip-magiclink
+#     make cloud-sync-iap-users
+#   plus a one-time manual `gcloud beta iap settings set` for gcipSettings.
 #
 # Midnight Infrastructure Versions:
 #   - Node: 0.20.1
@@ -761,8 +774,17 @@ steps:
         echo "Security URL: $$(cat /workspace/security-url.txt)"
 
   # ===========================================================================
-  # DEPLOY 5: opencode-login (public landing page)
+  # DEPLOY 5: opencode-login (magic-link sign-in UI; LB-only, public)
   # ===========================================================================
+  # The login UI hosts the email-input page (/login) and the Firebase email-link
+  # return handler (/__/auth/handler). It MUST remain unauthenticated (no IAP)
+  # because it IS the sign-in page, but it should only be reachable through the
+  # External LB (path-based routing on dcoder.<base_domain>) so it cannot be
+  # accessed via the raw run.app URL.
+  #
+  # Firebase config values (FIREBASE_API_KEY, FIREBASE_AUTH_DOMAIN) are
+  # browser-safe public values — security comes from authorized domains in the
+  # Firebase Console, not from secrecy. Pass via _FIREBASE_* substitutions.
 
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'deploy-login'
@@ -775,13 +797,13 @@ steps:
       - '--region=${_REGION}'
       - '--platform=managed'
       - '--allow-unauthenticated'
-      - '--ingress=all'
+      - '--ingress=internal-and-cloud-load-balancing'
       - '--port=8080'
       - '--memory=256Mi'
       - '--cpu=1'
       - '--min-instances=0'
       - '--max-instances=2'
-      - '--set-env-vars=NODE_ENV=production'
+      - '--set-env-vars=NODE_ENV=production,FIREBASE_API_KEY=${_FIREBASE_API_KEY},FIREBASE_AUTH_DOMAIN=${_FIREBASE_AUTH_DOMAIN},FIREBASE_PROJECT_ID=${PROJECT_ID}'
 
   # ===========================================================================
   # GET opencode-login URL
@@ -800,8 +822,11 @@ steps:
         echo "Login URL: $$(cat /workspace/login-url.txt)"
 
   # ===========================================================================
-  # DEPLOY 6: opencode-web (depends on all agents + login page, IAP protected)
+  # DEPLOY 6: opencode-web (depends on all agents + login page; LB-only ingress)
   # ===========================================================================
+  # No --iap flag here. IAP is enabled at the LB backend service layer
+  # (`opencode-web-backend`) with gcipSettings.tenantIds = ["_<project_number>"]
+  # for the GCIP "agent flow" pattern. See gcip-magiclink-setup.md.
 
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'deploy-opencode'
@@ -828,13 +853,12 @@ steps:
         PAYMENT_URL=$$(cat /workspace/payment-url.txt)
         SECURITY_URL=$$(cat /workspace/security-url.txt)
         LOGIN_URL=$$(cat /workspace/login-url.txt)
-        gcloud beta run deploy opencode-web \
+        gcloud run deploy opencode-web \
           --image=${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/opencode-web:${_TAG} \
           --region=${_REGION} \
           --platform=managed \
           --no-allow-unauthenticated \
-          --iap \
-          --ingress=all \
+          --ingress=internal-and-cloud-load-balancing \
           --port=8080 \
           --memory=1Gi \
           --cpu=1 \
@@ -842,28 +866,14 @@ steps:
           --max-instances=10 \
           --set-env-vars="NODE_ENV=production,GOOGLE_CLOUD_PROJECT=${PROJECT_ID},GOOGLE_CLOUD_LOCATION=global,AGENT_REGISTRY_URL=$${REGISTRY_URL},SOMNIA_AGENT_URL=$${SOMNIA_URL},SONIC_AGENT_URL=$${SONIC_URL},MIDNIGHT_AGENT_URL=$${MIDNIGHT_URL},STORE_AGENT_URL=$${STORE_URL},PAYMENT_AGENT_URL=$${PAYMENT_URL},SECURITY_AGENT_URL=$${SECURITY_URL},LOGIN_PAGE_URL=$${LOGIN_URL}"
 
-  # ===========================================================================
-  # SETUP IAP: Grant IAP service agent run.invoker role
-  # ===========================================================================
-
-  - name: 'gcr.io/cloud-builders/gcloud'
-    id: 'setup-iap'
-    waitFor: ['deploy-opencode']
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        # Get project number
-        PROJECT_NUMBER=$$(gcloud projects describe ${PROJECT_ID} --format='value(projectNumber)')
-
-        # Grant IAP service agent the invoker role on opencode-web
-        gcloud run services add-iam-policy-binding opencode-web \
-          --region=${_REGION} \
-          --member="serviceAccount:service-$${PROJECT_NUMBER}@gcp-sa-iap.iam.gserviceaccount.com" \
-          --role=roles/run.invoker \
-          --quiet 2>/dev/null || true
-
-        echo "IAP service agent granted run.invoker role"
+  # NOTE: The previous `setup-iap` step (which granted the IAP service agent
+  # run.invoker via Cloud Run direct IAP) has been REMOVED.
+  #
+  # In the new architecture, IAP is enabled at the LB backend service
+  # (opencode-web-backend), and the LB serverless NEG service agent (NOT the
+  # IAP service agent) needs run.invoker on the Cloud Run service. That binding
+  # is provisioned by `make cloud-setup-lb` / managed manually one-time.
+  # See gcip-magiclink-setup.md.
 
   # ===========================================================================
   # UPDATE agent-registry with agent URLs
@@ -891,7 +901,10 @@ steps:
   # ===========================================================================
   # UPDATE opencode-login with APP_URL (opencode-web URL)
   # ===========================================================================
-  # The login page needs to know the main app URL for the "Sign in" button.
+  # The login page needs APP_URL as a fallback for "return to app" links.
+  # Under the LB-fronted architecture, the post-auth target is the deployment
+  # FQDN (dcoder.<base_domain>); APP_URL here is just the raw run.app URL of
+  # opencode-web for backward compat with non-LB local-dev fallbacks.
 
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'update-login'
@@ -937,17 +950,33 @@ steps:
         echo "  security-agent:  $$(cat /workspace/security-url.txt)"
         echo "  midnight-mcp:    $$(cat /workspace/midnight-mcp-url.txt)"
         echo "  evm-mcp:         $$(cat /workspace/evm-mcp-url.txt)"
-        echo "  opencode-login:  $$(cat /workspace/login-url.txt) (public landing page)"
+        echo "  opencode-login:  $$(cat /workspace/login-url.txt) (LB-only; reach via /login on the LB FQDN)"
         OPENCODE_URL=$$(gcloud run services describe opencode-web --region=${_REGION} --format='value(status.url)')
-        echo "  opencode-web:    $${OPENCODE_URL} (IAP protected)"
+        echo "  opencode-web:    $${OPENCODE_URL} (LB-only; IAP via gcipSettings on opencode-web-backend)"
         echo ""
-        echo "Access the application via the login page: $$(cat /workspace/login-url.txt)"
+        echo "Reach the application via the deployment FQDN configured in"
+        echo "config.toml [default.dns] (e.g. https://dcoder.<base_domain>/)."
+        echo "Run 'make cloud-setup-dns && make cloud-setup-lb' if you have"
+        echo "not yet provisioned the LB."
         echo ""
 
+# -----------------------------------------------------------------------------
+# Substitutions
+# -----------------------------------------------------------------------------
+# _FIREBASE_API_KEY and _FIREBASE_AUTH_DOMAIN are PUBLIC Firebase config values
+# (browser-safe). Get them from the Identity Toolkit admin/v2/projects API.
+# See gcip-magiclink-setup.md Phase 0. They are passed to opencode-login as
+# environment variables so the page can initialize the Firebase JS SDK.
+#
+# To override on the command line:
+#   gcloud builds submit \
+#     --substitutions=_FIREBASE_API_KEY=AIza...,_FIREBASE_AUTH_DOMAIN=kunal-scratch.firebaseapp.com,...
 substitutions:
   _REGION: us-central1
   _REPO: coding-labs
   _TAG: latest
+  _FIREBASE_API_KEY: ''
+  _FIREBASE_AUTH_DOMAIN: ''
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/onchain-agents/coding-labs/compose.yaml
+++ b/onchain-agents/coding-labs/compose.yaml
@@ -407,10 +407,13 @@ services:
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------
-  # OpenCode Login - Landing page with "Sign in with Google" (optional)
+  # OpenCode Login - Magic-link sign-in page (optional)
   # ---------------------------------------------------------------------------
   # Only starts when using --profile login
-  # In production, this is a separate Cloud Run service (public, no IAP)
+  # In production, this is a separate Cloud Run service behind the LB at /login
+  # and /__/auth/* (no IAP). The Firebase env vars are PUBLIC config values
+  # used by the browser SDK; security comes from authorized domains in the
+  # Firebase Console, not from secrecy.
   opencode-login:
     build:
       context: .
@@ -423,14 +426,37 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=8080
-      # URL of the main app (for "Sign in with Google" button)
+      # URL of the main app (used for "return to app" fallback)
       - APP_URL=http://localhost:${OPENCODE_FRONTEND_PORT:-3000}
+      # Firebase public config — set these in your shell or .env to test
+      # the magic-link UI locally. Without them, the page loads but sign-in
+      # will display a "Sign-in is not configured" error.
+      - FIREBASE_API_KEY=${FIREBASE_API_KEY:-}
+      - FIREBASE_AUTH_DOMAIN=${FIREBASE_AUTH_DOMAIN:-}
+      - FIREBASE_PROJECT_ID=${FIREBASE_PROJECT_ID:-}
     healthcheck:
       test: ['CMD', 'wget', '-q', '--spider', 'http://127.0.0.1:8080/health']
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 5s
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Firebase Auth Emulator - Optional offline GCIP for local magic-link testing
+  # ---------------------------------------------------------------------------
+  # Run with: docker compose --profile emulator up firebase-auth-emulator
+  # When enabled, point the opencode-login Firebase SDK at the emulator by
+  # setting FIREBASE_AUTH_EMULATOR_HOST=localhost:9099 in your shell before
+  # loading the page (the SDK reads it automatically when running in dev).
+  firebase-auth-emulator:
+    image: andreysenov/firebase-tools:latest
+    container_name: firebase-auth-emulator
+    profiles:
+      - emulator
+    command: firebase emulators:start --only auth --project=${FIREBASE_PROJECT_ID:-kunal-scratch}
+    ports:
+      - '9099:9099'
     restart: unless-stopped
 
 # ===========================================================================

--- a/onchain-agents/coding-labs/config.toml
+++ b/onchain-agents/coding-labs/config.toml
@@ -68,6 +68,38 @@ host = "localhost"
 port = 3000
 
 # -----------------------------------------------------------------------------
+# Cloud Run service routing for the LB + IAP + GCIP magic-link architecture
+# -----------------------------------------------------------------------------
+# These mirror the live Cloud Run service names. They define how the External
+# Application Load Balancer maps URL paths to backend services and which
+# backend service has IAP enabled.
+#
+# IMPORTANT: live Cloud Run service names are `opencode-web` and
+# `opencode-login`. The package directory is `packages/adk-backend/` for
+# legacy reasons (issue #61); cloudbuild.yaml deploys it as `opencode-web`.
+#
+# Path-based routing on the single subdomain `dcoder.<base_domain>`:
+#   /login*       → opencode-login (IAP DISABLED — public sign-in UI)
+#   /__/auth/*    → opencode-login (IAP DISABLED — Firebase auth handlers)
+#   /*  (default) → opencode-web   (IAP ENABLED via gcipSettings agent flow)
+
+[default.services.opencode-web]
+host = "0.0.0.0"
+port = 8080
+# Default backend — handles all paths NOT claimed by another service
+path_prefix = "/"
+# IAP enabled at LB backend service level (gcipSettings agent flow)
+iap_enabled = true
+
+[default.services.opencode-login]
+host = "0.0.0.0"
+port = 8080
+# Login UI at /login; Firebase Auth handlers at /__/auth/*
+path_prefixes = ["/login", "/__/auth"]
+# IAP MUST be disabled — this is the public sign-in page
+iap_enabled = false
+
+# -----------------------------------------------------------------------------
 # Agents (registered in agent-registry)
 # -----------------------------------------------------------------------------
 # Each agent references a service for URL construction.
@@ -265,19 +297,48 @@ opencode = "vertex-anthropic"
 # These must match agent IDs defined in [default.agents.*]
 default_agents = ["somnia", "sonic", "midnight", "store", "payment", "security"]
 
+# =============================================================================
+# DNS / Custom Domain Configuration
+# =============================================================================
+# Cross-project Cloud DNS managed zone hosting the dCoder deployment domain.
+# The DNS zone lives in a separate Argolis project; the Cloud Build SA must
+# have roles/dns.recordSetEditor on that project.
+#
+# Workflow:
+#   1. Fill in placeholders below with actual values
+#   2. Grant cross-project IAM (see gcip-magiclink-setup.md)
+#   3. Run: make cloud-setup-gcip-magiclink
+#   4. Run: make cloud-setup-dns
+#   5. Run: make cloud-setup-lb
+#   6. Run: make cloud-sync-iap-users
+
+[default.dns]
+# Argolis project hosting the Cloud DNS managed zone (cross-project)
+project_id = "<DNS_PROJECT_ID>"
+
+# Cloud DNS managed-zone resource name (GCP resource ID, NOT the DNS name)
+zone_name = "<ZONE_NAME>"
+
+# Root DNS name of the managed zone (with trailing dot per Cloud DNS convention)
+# e.g. "kunall.demo.altostrat.com."
+base_domain = "<BASE_DOMAIN>"
+
+# Subdomain for the dCoder deployment (relative to base_domain)
+# Constructs the full FQDN: dcoder.<base_domain>
+subdomain = "dcoder"
+
 # -----------------------------------------------------------------------------
 # Authentication (IAP user whitelist)
 # -----------------------------------------------------------------------------
-# Users listed here will be granted access to opencode-web via IAP.
+# Users listed here are granted access to the IAP-protected backend service
+# (`opencode-web-backend`) at the LB layer. With GCIP-issued tokens via the
+# magic-link "agent flow", IAP IAM works for ANY email address (not just
+# Workspace-managed accounts).
 #
 # Workflow:
 #   1. Add/remove emails from allowed_users list
-#   2. Run: make cloud-sync-users    # Sync IAP bindings
+#   2. Run: make cloud-sync-iap-users    # Sync IAP bindings on backend service
 #   3. Changes take effect immediately
-#
-# NOTE: This project is deployed on an Argolis (Google internal demo) org.
-# Only @kunall.altostrat.com users can access IAP-protected resources.
-# External users require deployment to a non-Argolis GCP project.
 
 [default.auth]
 allowed_users = [

--- a/onchain-agents/coding-labs/gcip-magiclink-setup.md
+++ b/onchain-agents/coding-labs/gcip-magiclink-setup.md
@@ -1,0 +1,315 @@
+# GCIP Magic-Link Sign-In Setup (v1)
+
+This document covers the one-time bootstrap for the **v1 magic-link
+authentication architecture** introduced by issue #60. It supersedes the
+direct Cloud Run IAP setup that was used previously (and the multi-IDP plan
+described in issue #59, which is now closed).
+
+It assumes:
+
+- The Argolis project `kunal-scratch` is already deployed with all Cloud Run
+  services running (see `cloudbuild.yaml` / `make cloud-deploy`).
+- A Cloud DNS managed zone exists in a **separate Argolis project** that you
+  control (cross-project DNS pattern).
+
+For background and architecture rationale, see issue #60 and its v1 scope
+comment.
+
+---
+
+## Overview
+
+```
+                 dcoder.<base_domain>
+                          │
+                          ▼
+       ┌───────────────────────────────────┐
+       │  External HTTPS Load Balancer     │
+       │  (kunal-scratch project)          │
+       │                                   │
+       │  URL map:                         │
+       │   /login*       → opencode-login  │
+       │   /__/auth/*    → opencode-login  │
+       │   /*  (default) → opencode-web    │
+       └───────────────────────────────────┘
+              │                       │
+              ▼                       ▼
+        opencode-login           opencode-web
+        (no IAP)                 (IAP via gcipSettings
+                                  agent flow)
+```
+
+---
+
+## Phase 0 — Prerequisites (~5 min)
+
+### Required configuration values
+
+Fill in these placeholders in `config.toml [default.dns]`:
+
+| Field | Description | Example |
+|---|---|---|
+| `project_id` | Argolis project hosting the Cloud DNS managed zone | `dns-host-project` |
+| `zone_name`  | GCP resource name of the managed zone (NOT the DNS name) | `kunall-demo-altostrat-com` |
+| `base_domain`| Root DNS name of the zone with **trailing dot** | `kunall.demo.altostrat.com.` |
+| `subdomain`  | Subdomain for the dCoder deployment | `dcoder` |
+
+The full FQDN for the deployment is constructed as `<subdomain>.<base_domain>`,
+e.g. `dcoder.kunall.demo.altostrat.com`.
+
+To list available managed zones:
+
+```bash
+gcloud dns managed-zones list --project=<dns-project-id>
+```
+
+### Cross-project DNS IAM grant
+
+The Cloud Build service account in `kunal-scratch` must be able to create A
+records in the DNS-hosting project. Grant `roles/dns.recordSetEditor` on that
+project:
+
+```bash
+PROJECT_NUMBER=$(gcloud projects describe kunal-scratch --format='value(projectNumber)')
+
+# Cloud Build SA
+gcloud projects add-iam-policy-binding <DNS_PROJECT_ID> \
+  --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+  --role=roles/dns.recordSetEditor
+
+# Default compute SA (used by cloudbuild deploy steps)
+gcloud projects add-iam-policy-binding <DNS_PROJECT_ID> \
+  --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
+  --role=roles/dns.recordSetEditor
+```
+
+### Firebase public config
+
+The opencode-login service needs Firebase public config values
+(`apiKey`, `authDomain`). These are **browser-safe public values** —
+security is enforced via authorized domain whitelisting in the Firebase
+Console plus Firebase Security Rules, not via secrecy of the apiKey.
+
+Get them from the Identity Toolkit admin API:
+
+```bash
+ACCESS_TOKEN=$(gcloud auth print-access-token)
+curl -sH "Authorization: Bearer $ACCESS_TOKEN" \
+     -H "x-goog-user-project: kunal-scratch" \
+     https://identitytoolkit.googleapis.com/admin/v2/projects/kunal-scratch/config
+```
+
+The response contains `client.apiKey` and `client.firebaseSubdomain`. The
+`apiKey` is for `FIREBASE_API_KEY`. The auth domain is
+`<firebaseSubdomain>.firebaseapp.com`.
+
+Set these as Cloud Build substitutions when triggering a deploy:
+
+```bash
+gcloud builds submit \
+  --config=cloudbuild.yaml \
+  --substitutions=_FIREBASE_API_KEY=AIza...,_FIREBASE_AUTH_DOMAIN=kunal-scratch.firebaseapp.com
+```
+
+Or add them to your shell/`.env` for local testing.
+
+---
+
+## Phase 1 — Enable GCIP magic-link sign-in (~2 min)
+
+```bash
+make cloud-setup-gcip-magiclink
+```
+
+This makes a single PATCH call to the Identity Toolkit Admin API:
+
+```
+PATCH https://identitytoolkit.googleapis.com/admin/v2/projects/kunal-scratch/config?updateMask=signIn.email
+{
+  "signIn": {
+    "email": {
+      "enabled": true,
+      "passwordRequired": false
+    }
+  }
+}
+```
+
+After this, magic-link email sign-in is enabled. **No OAuth providers are
+configured** in v1 — only email link.
+
+---
+
+## Phase 2 — Set up DNS (~2 min)
+
+```bash
+make cloud-setup-dns
+```
+
+This:
+
+1. Reserves a global IP `opencode-web-lb-ip` in `kunal-scratch` (if not already).
+2. Reads DNS values from `config.toml [default.dns]`.
+3. Creates (or updates) an A record in the cross-project zone pointing to the LB IP.
+
+---
+
+## Phase 3 — Provision LB resources (~10 min)
+
+```bash
+make cloud-setup-lb
+```
+
+This provisions:
+
+- Google-managed SSL cert for the FQDN (provisioning is asynchronous and
+  takes 10–15 min after DNS resolves).
+- Two serverless NEGs (one per Cloud Run service: `opencode-web-neg` and
+  `opencode-login-neg`).
+- Two backend services:
+  - `opencode-web-backend` — IAP-enabled (gcipSettings applied in Phase 4)
+  - `opencode-login-backend` — public, no IAP
+- URL map `opencode-url-map` with path-based routing:
+  - `/login*` and `/__/auth/*` → `opencode-login-backend`
+  - everything else (default) → `opencode-web-backend`
+- Target HTTPS proxy `opencode-https-proxy` using the URL map + cert.
+- Global forwarding rule `opencode-fwd-rule` (port 443, target=https-proxy,
+  address=opencode-web-lb-ip).
+
+The cert provisioning is async; watch its status with:
+
+```bash
+gcloud compute ssl-certificates describe opencode-web-cert --global \
+  --project=kunal-scratch \
+  --format='get(managed.status,managed.domainStatus)'
+```
+
+When status shows `ACTIVE`, the LB is ready to serve traffic.
+
+---
+
+## Phase 4 — Apply IAP gcipSettings (manual, one-time)
+
+The agent-flow gcipSettings YAML is currently applied via a one-time manual
+gcloud command. (`cmd_setup_lb` enables IAP but does NOT yet apply the YAML
+because the binding requires the LB to be active and the apiKey to be known.)
+
+This is the critical "agent-flow" pattern using `tenantIds: ["_<project_number>"]`:
+
+```bash
+PROJECT_NUMBER=$(gcloud projects describe kunal-scratch --format='value(projectNumber)')
+SUBDOMAIN=dcoder                    # from config.toml
+BASE_DOMAIN=kunall.demo.altostrat.com  # from config.toml (trailing dot stripped)
+
+cat > /tmp/iap_gcip.yaml <<EOF
+accessSettings:
+  gcipSettings:
+    tenantIds:
+    - _${PROJECT_NUMBER}
+    loginPageUri: https://${SUBDOMAIN}.${BASE_DOMAIN}/login
+EOF
+
+gcloud beta iap settings set /tmp/iap_gcip.yaml \
+  --project=kunal-scratch \
+  --resource-type=backend-services \
+  --service=opencode-web-backend
+```
+
+**Important note:** the `_${PROJECT_NUMBER}` tenantId pattern (underscore +
+project number) is undocumented in public IAP docs but was empirically
+validated by pilot session `/tmp/pilot-gcip-orgpolicy-220993ee`. It activates
+the GCIP "agent flow" — project-scoped GCIP without requiring multi-tenancy.
+
+---
+
+## Phase 5 — Sync IAP IAM users (~1 min)
+
+```bash
+make cloud-sync-iap-users
+```
+
+This binds each user from `config.toml [default.auth].allowed_users` to
+`opencode-web-backend` IAP IAM with `roles/iap.httpsResourceAccessor`. With
+GCIP-issued tokens via the agent-flow pattern, IAP IAM works for ANY email
+(not just Workspace-managed accounts).
+
+---
+
+## Verification
+
+Visit `https://<subdomain>.<base_domain>` (e.g.
+`https://dcoder.kunall.demo.altostrat.com`).
+
+Expected flow:
+
+1. Redirect to `/login` — URL bar stays on the same hostname.
+2. Email input renders with dCoder branding.
+3. Enter your email → "Check your email" message.
+4. Click magic link in email → returns to `/__/auth/handler?...`.
+5. Handler completes sign-in → redirects to original URL.
+6. App loads (your email must be in `config.toml [default.auth].allowed_users`).
+
+If sign-in fails at step 5, see "IAP+GCIP redirect-back" in the
+"Open issues" section below.
+
+---
+
+## Rollback
+
+To remove LB resources and revert to direct Cloud Run access:
+
+```bash
+make cloud-teardown-lb
+
+# Optional: re-open Cloud Run services to public ingress
+gcloud run services update opencode-web \
+  --ingress=all --region=us-central1 --project=kunal-scratch
+gcloud run services update opencode-login \
+  --ingress=all --region=us-central1 --project=kunal-scratch
+```
+
+The DNS A record is left in place by `cloud-teardown-lb` (since it lives in a
+different project). Delete it manually if needed:
+
+```bash
+gcloud dns record-sets delete dcoder.<base_domain>. --type=A \
+  --zone=<zone-name> --project=<dns-project-id>
+```
+
+---
+
+## Open issues / TODOs
+
+### IAP+GCIP redirect-back contract
+
+The `__/auth/handler.html` page currently uses a simple "redirect to original
+URL" pattern after `signInWithEmailLink` succeeds. In some IAP+GCIP agent-flow
+deployments, additional steps are required:
+
+- POSTing the ID token to an IAP-specific endpoint, OR
+- Relying on the Firebase JS SDK's automatic session-cookie behaviour (which
+  requires `authDomain` to match the IAP-bound hostname).
+
+If users complete sign-in but get bounced back to `/login` instead of seeing
+the protected app, follow the IAP external-identities documentation:
+
+- https://cloud.google.com/iap/docs/external-identities
+- https://firebase.google.com/docs/auth/web/email-link-auth
+
+The handler page documents this caveat inline.
+
+### `cmd_setup_lb` does not apply gcipSettings
+
+`cmd_setup_lb` enables IAP on `opencode-web-backend` but does not apply the
+gcipSettings YAML. That step is currently manual (Phase 4 above). A future
+enhancement is to extend `cmd_setup_lb` to construct and apply the YAML
+automatically once the apiKey is available.
+
+---
+
+## Related
+
+- Issue #60 — Migration tracking (this work)
+- Issue #61 — Naming reconciliation (`opencode-web` vs `adk-backend`,
+  resolved as part of #60 by standardizing cloudbuild on `opencode-web`)
+- Issue #59 — Original cross-project Firebase plan (closed, superseded)

--- a/onchain-agents/coding-labs/packages/opencode-login/README.md
+++ b/onchain-agents/coding-labs/packages/opencode-login/README.md
@@ -1,26 +1,53 @@
 # dCoder Login Page
 
-Landing page for dCoder with "Sign in with Google" functionality.
+Magic-link email sign-in UI for dCoder, hosted at `/login` and `/__/auth/*`
+on the deployment FQDN (e.g. `dcoder.<base_domain>`).
 
 ## Overview
 
-This is a simple static landing page that:
-- Displays the dCoder branding with ASCII art
-- Shows key features of the platform
-- Provides a "Sign in with Google" button that redirects to the IAP-protected main app
+This service hosts:
+
+- The dCoder branded landing page with an email input + "Send magic link" button
+- The `/__/auth/handler` endpoint that completes Firebase email-link sign-in
+  and redirects the user back to the IAP-protected app
+
+It is deployed as a public Cloud Run service with `--ingress=internal-and-cloud-load-balancing`
+so it is only reachable through the External HTTPS Load Balancer (which
+routes `/login*` and `/__/auth/*` paths to it).
 
 ## Architecture
 
 ```
-┌──────────────────────┐         ┌──────────────────────────┐
-│   opencode-login     │         │      opencode-web        │
-│   (Public)           │         │   (IAP Protected)        │
-│                      │         │                          │
-│   Landing page with  │  ──→    │   Main application       │
-│   "Sign in" button   │  click  │   IAP handles Google     │
-│                      │         │   OAuth automatically    │
-└──────────────────────┘         └──────────────────────────┘
+┌──────────────────────────┐       ┌─────────────────────────────┐
+│   opencode-login         │       │      opencode-web           │
+│   (public, no IAP)       │       │   (IAP via gcipSettings     │
+│                          │       │    agent flow)              │
+│   /login                 │       │                             │
+│     ▲                    │       │   Main application          │
+│     │ user enters email  │       │   Receives x-goog-iap-jwt-  │
+│     ▼                    │       │   assertion + enforces      │
+│   Firebase JS SDK        │       │   config.toml allow-list    │
+│     ▲                    │       │                             │
+│     │ magic link in      │       └────────────▲────────────────┘
+│     │ email              │                    │
+│     ▼                    │                    │
+│   /__/auth/handler       │ signInWithEmailLink│
+│     ▲                    │ → ID token         │
+│     │ user clicks link   │ → IAP session      │
+│     ▼                    │ ───────────────────┘
+│   redirect to original   │
+│   target URL             │
+└──────────────────────────┘
+
+  All paths share the same hostname (dcoder.<base_domain>) — no
+  cross-domain bouncing. The LB URL map handles routing:
+
+      /login*       → opencode-login-backend (no IAP)
+      /__/auth/*    → opencode-login-backend (no IAP)
+      /*  (default) → opencode-web-backend   (IAP enabled)
 ```
+
+See `gcip-magiclink-setup.md` for the one-time bootstrap.
 
 ## Development
 
@@ -32,9 +59,24 @@ cd packages/opencode-login
 npm install
 
 # Run locally
-APP_URL=http://localhost:4097 npm start
+APP_URL=http://localhost:4097 \
+  FIREBASE_API_KEY=<your-key> \
+  FIREBASE_AUTH_DOMAIN=<project>.firebaseapp.com \
+  FIREBASE_PROJECT_ID=<project> \
+  npm start
 
-# Visit http://localhost:8080
+# Visit http://localhost:8080/login
+```
+
+If the Firebase env vars are unset, the page renders but clicking "Send magic
+link" will display a "Sign-in is not configured" error.
+
+For fully offline testing, run the Firebase Auth emulator:
+
+```bash
+docker compose --profile emulator up firebase-auth-emulator
+# then export FIREBASE_AUTH_EMULATOR_HOST=localhost:9099 before
+# loading the page in your browser
 ```
 
 ### With Docker/Podman
@@ -44,7 +86,12 @@ APP_URL=http://localhost:4097 npm start
 podman build -f packages/opencode-login/Containerfile -t opencode-login .
 
 # Run
-podman run -p 8080:8080 -e APP_URL=http://localhost:4097 opencode-login
+podman run -p 8080:8080 \
+  -e APP_URL=http://localhost:4097 \
+  -e FIREBASE_API_KEY=<your-key> \
+  -e FIREBASE_AUTH_DOMAIN=<project>.firebaseapp.com \
+  -e FIREBASE_PROJECT_ID=<project> \
+  opencode-login
 ```
 
 ### With Docker Compose (optional profile)
@@ -53,8 +100,8 @@ podman run -p 8080:8080 -e APP_URL=http://localhost:4097 opencode-login
 # From project root - includes login page
 docker compose --profile login up
 
-# Login page: http://localhost:4098
-# Main app:   http://localhost:4097 (or 3000 in container mode)
+# Login page: http://localhost:4098/login
+# Main app:   http://localhost:4097 (or 8181 for adk-backend)
 ```
 
 ## Environment Variables
@@ -62,20 +109,31 @@ docker compose --profile login up
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `PORT` | Server port | `8080` |
-| `APP_URL` | URL of the main application (IAP-protected) | `http://localhost:4097` |
+| `APP_URL` | URL of the main application (fallback for "return to app" links) | `http://localhost:4097` |
+| `FIREBASE_API_KEY` | Public Firebase Web API key (browser-safe) | `""` |
+| `FIREBASE_AUTH_DOMAIN` | Firebase auth domain, typically `<project>.firebaseapp.com` | `""` |
+| `FIREBASE_PROJECT_ID` | GCP project ID hosting GCIP | `""` |
+
+The Firebase values are PUBLIC config (browser-safe) — security comes from
+authorized-domain whitelisting in the Firebase Console + Firebase Security
+Rules, not from secrecy of the apiKey. See `gcip-magiclink-setup.md`
+Phase 0 for how to retrieve them.
 
 ## Endpoints
 
 | Endpoint | Description |
 |----------|-------------|
 | `GET /` | Landing page HTML |
+| `GET /login` | Magic-link sign-in page (alias for `/`) |
+| `GET /__/auth/handler` | Email-link return handler (completes sign-in) |
 | `GET /health` | Health check |
-| `GET /config` | Returns `{ appUrl: "..." }` for the frontend |
+| `GET /config` | Returns `{ appUrl, firebase: { apiKey, authDomain, projectId } }` for the SPA |
 
 ## Deployment
 
-The login page is deployed to Cloud Run as a public service (no authentication required).
-The "Sign in with Google" button links to the IAP-protected main app, which triggers
-Google's OAuth flow automatically.
+The login page is deployed as a Cloud Run service with LB-only ingress
+(`--ingress=internal-and-cloud-load-balancing`) so it can only be reached
+through the External HTTPS Load Balancer. The LB URL map routes `/login*`
+and `/__/auth/*` requests to this backend without IAP.
 
-See `cloudbuild.yaml` for deployment configuration.
+See `cloudbuild.yaml` and `gcip-magiclink-setup.md` for deployment details.

--- a/onchain-agents/coding-labs/packages/opencode-login/public/__/auth/handler.html
+++ b/onchain-agents/coding-labs/packages/opencode-login/public/__/auth/handler.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Signing you in… | dCoder</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <!--
+      Magic-link email return handler (issue #60).
+
+      The user lands here after clicking the link sent to their inbox. This
+      page completes the Firebase email-link sign-in flow against the GCIP
+      tenant configured for the project, then redirects back to the original
+      target URL (which is then handled by IAP at the LB backend service).
+
+      This page is reachable at /__/auth/handler on the SAME hostname as the
+      protected app (dcoder.<base_domain>); the LB URL map routes /__/auth/*
+      to the opencode-login backend (no IAP), while /* defaults to the
+      IAP-protected opencode-web backend.
+    -->
+    <div class="dcoder-content" style="text-align: center; padding: 60px 20px;">
+      <h1 id="status-title">Signing you in…</h1>
+      <p id="status-message">Please wait while we complete your sign-in.</p>
+      <p id="status-error" class="signin-error" hidden></p>
+    </div>
+
+    <script type="module">
+      import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.0.2/firebase-app.js';
+      import {
+        getAuth,
+        isSignInWithEmailLink,
+        signInWithEmailLink,
+      } from 'https://www.gstatic.com/firebasejs/11.0.2/firebase-auth.js';
+
+      function showError(msg) {
+        document.getElementById('status-title').textContent = 'Sign-in error';
+        document.getElementById('status-message').hidden = true;
+        const err = document.getElementById('status-error');
+        err.textContent = msg + ' Return to the ';
+        const link = document.createElement('a');
+        link.href = '/login';
+        link.textContent = 'sign-in page';
+        link.style.color = 'var(--accent-orange)';
+        err.appendChild(link);
+        err.appendChild(document.createTextNode('.'));
+        err.hidden = false;
+      }
+
+      async function completeSignIn() {
+        let config;
+        try {
+          const response = await fetch('/config');
+          config = await response.json();
+        } catch (err) {
+          console.error('[handler] Failed to fetch /config:', err);
+          showError('Sign-in is not available.');
+          return;
+        }
+
+        if (!config.firebase || !config.firebase.apiKey) {
+          showError('Sign-in is not configured.');
+          return;
+        }
+
+        const app = initializeApp(config.firebase);
+        const auth = getAuth(app);
+
+        if (!isSignInWithEmailLink(auth, window.location.href)) {
+          showError('This link is invalid or expired. Please request a new one.');
+          return;
+        }
+
+        let email = window.localStorage.getItem('emailForSignIn');
+        if (!email) {
+          // The user opened the link on a different device/browser than the
+          // one that issued it. Confirm the email manually.
+          email = window.prompt(
+            'Please confirm your email address to complete sign-in:'
+          );
+          if (!email) {
+            showError('Email required to complete sign-in.');
+            return;
+          }
+        }
+
+        try {
+          await signInWithEmailLink(auth, email, window.location.href);
+          window.localStorage.removeItem('emailForSignIn');
+
+          // Redirect back to the original target. IAP's gcipSettings flow
+          // sets a `state` (or `continueUri`) query parameter with the
+          // original URL the user requested. Fall back to '/' if neither is
+          // present (e.g., a user invoked the link directly).
+          //
+          // NOTE: the precise IAP+GCIP redirect-back contract may require
+          // additional steps (e.g. POSTing the ID token to an IAP-specific
+          // endpoint, or relying on the Firebase JS SDK's automatic
+          // session-cookie behaviour when authDomain matches the IAP-bound
+          // hostname). The simple redirect-to-target pattern shown here is
+          // the documented "happy path" for the agent flow.
+          // See: https://cloud.google.com/iap/docs/external-identities
+          const params = new URLSearchParams(window.location.search);
+          const continueUri =
+            params.get('continueUri') || params.get('state') || '/';
+          window.location.href = continueUri;
+        } catch (err) {
+          console.error('[handler] signInWithEmailLink failed:', err);
+          showError(err.message || 'Sign-in failed. Try again.');
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', completeSignIn);
+    </script>
+  </body>
+</html>

--- a/onchain-agents/coding-labs/packages/opencode-login/public/index.html
+++ b/onchain-agents/coding-labs/packages/opencode-login/public/index.html
@@ -77,7 +77,7 @@
             />
           </svg>
         </button>
-        <a href="#" id="signin-btn" class="header-signin-btn">Sign in</a>
+        <a href="#signin-container" id="signin-btn" class="header-signin-btn">Sign in</a>
       </div>
     </header>
 
@@ -578,32 +578,52 @@
               <li>Integrated with Google Cloud for enterprise scale</li>
             </ul>
 
-            <a href="#" id="dcoder-signin-btn" class="signin-button">
-              <svg
-                class="google-icon"
-                viewBox="0 0 24 24"
-                width="20"
-                height="20"
-              >
-                <path
-                  fill="#ffffff"
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+            <!-- Magic-link sign-in (issue #60). The legacy Google OAuth
+                 button has been replaced with email-link auth via Firebase /
+                 GCIP. The handler page lives at /__/auth/handler. -->
+            <div id="signin-container">
+              <div id="email-input-state">
+                <input
+                  type="email"
+                  id="email-input"
+                  class="email-input"
+                  placeholder="you@example.com"
+                  autocomplete="email"
+                  required
                 />
-                <path
-                  fill="#ffffff"
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                />
-                <path
-                  fill="#ffffff"
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                />
-                <path
-                  fill="#ffffff"
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                />
-              </svg>
-              Sign in with Google
-            </a>
+                <button id="send-link-btn" class="signin-button">
+                  <svg
+                    class="email-icon"
+                    viewBox="0 0 24 24"
+                    width="20"
+                    height="20"
+                  >
+                    <path
+                      fill="#ffffff"
+                      d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"
+                    />
+                  </svg>
+                  Send magic link
+                </button>
+                <p id="signin-error" class="signin-error" hidden></p>
+              </div>
+
+              <div id="check-email-state" hidden>
+                <div class="check-email-icon">📧</div>
+                <h3 class="check-email-title">Check your email</h3>
+                <p class="check-email-body">
+                  We sent a magic link to
+                  <strong id="sent-to-email"></strong>.
+                </p>
+                <p class="signin-hint">
+                  Click the link to complete sign-in. The link expires in
+                  15 minutes.
+                </p>
+                <button id="resend-link-btn" class="signin-button-secondary">
+                  Send another link
+                </button>
+              </div>
+            </div>
 
             <div class="divider"></div>
 
@@ -667,25 +687,121 @@
         scrim.classList.remove('visible');
       });
 
-      // --- Fetch config for sign-in ---
-      async function init() {
-        try {
-          const response = await fetch('/config');
-          const config = await response.json();
-          if (config.appUrl) {
-            document.getElementById('signin-btn').href = config.appUrl;
-            document.getElementById('dcoder-signin-btn').href = config.appUrl;
-          }
-        } catch (err) {
-          console.error('Failed to fetch config:', err);
-          document.getElementById('signin-btn').href = '/';
-          document.getElementById('dcoder-signin-btn').href = '/';
-        }
-      }
-      init();
+      // The legacy init() that wired the Google sign-in button to APP_URL is
+      // gone — sign-in now happens via the magic-link module script below.
+      // The header "Sign in" link just anchors to the email input section.
 
       // Show dCoder page by default
       showPage('dcoder');
+    </script>
+
+    <!--
+      Magic-link sign-in module (issue #60).
+      Loads Firebase JS SDK from the official CDN, fetches public config
+      from /config, and wires up the email input + send-link button.
+    -->
+    <script type="module">
+      import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.0.2/firebase-app.js';
+      import {
+        getAuth,
+        sendSignInLinkToEmail,
+      } from 'https://www.gstatic.com/firebasejs/11.0.2/firebase-auth.js';
+
+      function showError(msg) {
+        const errEl = document.getElementById('signin-error');
+        if (!errEl) return;
+        errEl.textContent = msg;
+        errEl.hidden = false;
+      }
+
+      function clearError() {
+        const errEl = document.getElementById('signin-error');
+        if (errEl) {
+          errEl.hidden = true;
+          errEl.textContent = '';
+        }
+      }
+
+      async function initFirebaseAuth() {
+        let config;
+        try {
+          const response = await fetch('/config');
+          config = await response.json();
+        } catch (err) {
+          console.error('[opencode-login] Failed to fetch /config:', err);
+          showError('Sign-in is not available. Please try again later.');
+          return;
+        }
+
+        if (!config.firebase || !config.firebase.apiKey) {
+          console.error(
+            '[opencode-login] Firebase config missing — set FIREBASE_API_KEY env var on opencode-login'
+          );
+          showError('Sign-in is not configured. Contact the administrator.');
+          return;
+        }
+
+        const app = initializeApp(config.firebase);
+        const auth = getAuth(app);
+
+        const emailInput = document.getElementById('email-input');
+        const sendBtn = document.getElementById('send-link-btn');
+        const resendBtn = document.getElementById('resend-link-btn');
+        const inputState = document.getElementById('email-input-state');
+        const checkState = document.getElementById('check-email-state');
+        const sentToEmail = document.getElementById('sent-to-email');
+
+        async function sendLink(email) {
+          clearError();
+          // The magic link returns the user to /__/auth/handler on the same
+          // hostname (the LB FQDN, e.g. dcoder.<base_domain>). The URL map
+          // routes /__/auth/* to opencode-login (no IAP), where handler.html
+          // calls signInWithEmailLink and forwards the user back to IAP.
+          const actionCodeSettings = {
+            url: window.location.origin + '/__/auth/handler',
+            handleCodeInApp: true,
+          };
+          try {
+            await sendSignInLinkToEmail(auth, email, actionCodeSettings);
+            window.localStorage.setItem('emailForSignIn', email);
+            sentToEmail.textContent = email;
+            inputState.hidden = true;
+            checkState.hidden = false;
+          } catch (err) {
+            console.error('[opencode-login] sendSignInLinkToEmail failed:', err);
+            showError(err.message || 'Failed to send link. Try again.');
+          }
+        }
+
+        sendBtn.addEventListener('click', () => {
+          const email = emailInput.value.trim();
+          if (!email) {
+            showError('Enter your email address.');
+            return;
+          }
+          sendLink(email);
+        });
+
+        emailInput.addEventListener('keypress', (e) => {
+          if (e.key === 'Enter') sendBtn.click();
+        });
+
+        emailInput.addEventListener('input', clearError);
+
+        resendBtn.addEventListener('click', () => {
+          const email =
+            window.localStorage.getItem('emailForSignIn') ||
+            (emailInput && emailInput.value.trim());
+          if (email) {
+            // Reset to input state so the user sees the result of resending.
+            checkState.hidden = true;
+            inputState.hidden = false;
+            sendLink(email);
+          }
+        });
+      }
+
+      document.addEventListener('DOMContentLoaded', initFirebaseAuth);
     </script>
   </body>
 </html>

--- a/onchain-agents/coding-labs/packages/opencode-login/public/styles.css
+++ b/onchain-agents/coding-labs/packages/opencode-login/public/styles.css
@@ -969,3 +969,113 @@ body {
     transition: none;
   }
 }
+
+/* =========================================
+   MAGIC-LINK SIGN-IN UI (issue #60)
+   ========================================= */
+#signin-container {
+  width: 100%;
+  max-width: 420px;
+  margin: 16px auto 0;
+  text-align: left;
+}
+
+.email-input {
+  width: 100%;
+  padding: 14px 16px;
+  font-size: 1rem;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  margin-bottom: 12px;
+  font-family: 'Google Sans Text', Roboto, Arial, sans-serif;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.email-input::placeholder {
+  color: var(--text-muted);
+}
+
+.email-input:focus {
+  outline: none;
+  border-color: var(--accent-orange);
+  box-shadow: 0 0 0 3px rgba(255, 119, 0, 0.18);
+}
+
+#email-input-state .signin-button {
+  width: 100%;
+}
+
+.email-icon {
+  flex-shrink: 0;
+}
+
+.signin-error {
+  color: #ff8a80; /* dark-theme friendly red */
+  font-size: 0.9rem;
+  margin-top: 8px;
+  text-align: center;
+}
+
+.check-email-icon {
+  font-size: 48px;
+  margin-bottom: 12px;
+  text-align: center;
+}
+
+.check-email-title {
+  color: var(--text-primary);
+  font-family: 'Google Sans', Roboto, Arial, sans-serif;
+  font-size: 1.25rem;
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.check-email-body {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  margin-bottom: 8px;
+  text-align: center;
+  word-break: break-all;
+}
+
+.signin-hint {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  text-align: center;
+  margin-bottom: 16px;
+}
+
+.signin-button-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 12px 24px;
+  background: transparent;
+  border: 1px solid var(--accent-orange);
+  color: var(--accent-orange);
+  font-family: 'Google Sans', Roboto, Arial, sans-serif;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  margin-top: 8px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.signin-button-secondary:hover {
+  background: rgba(255, 119, 0, 0.1);
+}
+
+.signin-button-secondary:active {
+  background: rgba(255, 119, 0, 0.2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .email-input,
+  .signin-button-secondary {
+    transition: none;
+  }
+}

--- a/onchain-agents/coding-labs/packages/opencode-login/server.js
+++ b/onchain-agents/coding-labs/packages/opencode-login/server.js
@@ -1,8 +1,20 @@
 /**
  * dCoder Login Page Server
  *
- * Simple Express static file server for the login landing page.
- * Serves files from the public/ directory.
+ * Express server hosting the magic-link sign-in UI under the LB + IAP + GCIP
+ * agent-flow architecture (issue #60).
+ *
+ * Routes:
+ *   GET /health         — liveness probe
+ *   GET /config         — public Firebase config + APP_URL for the SPA
+ *   GET /login          — sign-in page (renders public/index.html)
+ *   GET /__/auth/handler — magic-link return handler (static file)
+ *   GET /*              — fallback to public/index.html
+ *
+ * Firebase env vars are PUBLIC (browser-safe):
+ *   - FIREBASE_API_KEY      — Identity Toolkit web API key
+ *   - FIREBASE_AUTH_DOMAIN  — typically <project>.firebaseapp.com
+ *   - FIREBASE_PROJECT_ID   — GCP project hosting GCIP
  */
 
 import express from 'express';
@@ -15,21 +27,39 @@ const __dirname = dirname(__filename);
 const app = express();
 const PORT = process.env.PORT || 8080;
 const APP_URL = process.env.APP_URL || 'http://localhost:4097';
+const FIREBASE_API_KEY = process.env.FIREBASE_API_KEY || '';
+const FIREBASE_AUTH_DOMAIN = process.env.FIREBASE_AUTH_DOMAIN || '';
+const FIREBASE_PROJECT_ID = process.env.FIREBASE_PROJECT_ID || '';
 
 // Health check endpoint
 app.get('/health', (req, res) => {
   res.json({ status: 'ok', service: 'opencode-login' });
 });
 
-// Serve APP_URL as a JSON endpoint for the frontend
+// Public Firebase config + app URL for the browser SPA
 app.get('/config', (req, res) => {
-  res.json({ appUrl: APP_URL });
+  res.json({
+    appUrl: APP_URL,
+    firebase: {
+      apiKey: FIREBASE_API_KEY,
+      authDomain: FIREBASE_AUTH_DOMAIN,
+      projectId: FIREBASE_PROJECT_ID,
+    },
+  });
 });
 
-// Serve static files from public directory
+// Explicit /login route — serves the same SPA as `/`. Declared BEFORE the
+// static middleware so it always resolves to index.html regardless of how the
+// LB URL map normalizes trailing slashes.
+app.get('/login', (req, res) => {
+  res.sendFile(join(__dirname, 'public', 'index.html'));
+});
+
+// Serve static files from public/ (includes /__/auth/handler.html and
+// /styles.css). Express resolves /__/auth/handler.html naturally.
 app.use(express.static(join(__dirname, 'public')));
 
-// Fallback to index.html for SPA-like behavior
+// Fallback to index.html for SPA-like behavior on unknown paths
 app.get('*', (req, res) => {
   res.sendFile(join(__dirname, 'public', 'index.html'));
 });
@@ -37,4 +67,9 @@ app.get('*', (req, res) => {
 app.listen(PORT, '0.0.0.0', () => {
   console.log(`[opencode-login] Server running on http://0.0.0.0:${PORT}`);
   console.log(`[opencode-login] APP_URL configured as: ${APP_URL}`);
+  console.log(
+    `[opencode-login] Firebase configured: ${
+      FIREBASE_API_KEY ? 'yes' : 'NO (sign-in will fail)'
+    }`
+  );
 });

--- a/onchain-agents/coding-labs/scripts/cloud.sh
+++ b/onchain-agents/coding-labs/scripts/cloud.sh
@@ -196,10 +196,253 @@ cmd_delete() {
   fi
 }
 
-cmd_sync_users() {
-  log_header "Syncing IAP users from config.toml"
-  
-  # Parse allowed_users from config.toml using bun
+# -----------------------------------------------------------------------------
+# Helpers for parsing [default.dns] from config.toml via smol-toml + bun
+# -----------------------------------------------------------------------------
+_dns_field() {
+  # $1 = field name (project_id, zone_name, base_domain, subdomain)
+  bun -e "
+    const fs = require('fs');
+    const { parse } = require('smol-toml');
+    const config = parse(fs.readFileSync('config.toml', 'utf-8'));
+    console.log(config.default?.dns?.${1} || '');
+  " 2>/dev/null
+}
+
+_require_dns_config() {
+  # Read all DNS fields and validate they're populated (not placeholder values).
+  # Sets DNS_PROJECT, ZONE_NAME, BASE_DOMAIN, SUBDOMAIN, FQDN as globals.
+  DNS_PROJECT=$(_dns_field project_id)
+  ZONE_NAME=$(_dns_field zone_name)
+  BASE_DOMAIN=$(_dns_field base_domain)
+  SUBDOMAIN=$(_dns_field subdomain)
+
+  if [[ -z "$DNS_PROJECT" || "$DNS_PROJECT" == "<DNS_PROJECT_ID>" ]]; then
+    log_error "config.toml [default.dns].project_id is not set."
+    log_error "Edit config.toml and fill in the [default.dns] block first."
+    log_error "See gcip-magiclink-setup.md Phase 0 for guidance."
+    return 1
+  fi
+  if [[ -z "$ZONE_NAME" || "$ZONE_NAME" == "<ZONE_NAME>" ]]; then
+    log_error "config.toml [default.dns].zone_name is not set."
+    return 1
+  fi
+  if [[ -z "$BASE_DOMAIN" || "$BASE_DOMAIN" == "<BASE_DOMAIN>" ]]; then
+    log_error "config.toml [default.dns].base_domain is not set."
+    return 1
+  fi
+  if [[ -z "$SUBDOMAIN" ]]; then
+    log_error "config.toml [default.dns].subdomain is not set."
+    return 1
+  fi
+
+  # Construct FQDN. base_domain may end with a dot (Cloud DNS convention).
+  # Strip trailing dot, concat subdomain, then re-add trailing dot.
+  FQDN="${SUBDOMAIN}.${BASE_DOMAIN%.}."
+  return 0
+}
+
+cmd_setup_dns() {
+  log_header "Setting up cross-project DNS A record"
+
+  _require_dns_config || return 1
+
+  log_info "DNS project:  $DNS_PROJECT"
+  log_info "Managed zone: $ZONE_NAME"
+  log_info "FQDN:         $FQDN"
+  echo ""
+
+  # Reserve global IP in kunal-scratch (LB project) if not already present
+  LB_IP=$(gcloud compute addresses describe opencode-web-lb-ip \
+    --global --project="$PROJECT_ID" --format='value(address)' 2>/dev/null || true)
+
+  if [[ -z "$LB_IP" ]]; then
+    log_info "Reserving global IP: opencode-web-lb-ip"
+    gcloud compute addresses create opencode-web-lb-ip \
+      --global --project="$PROJECT_ID" --quiet
+    LB_IP=$(gcloud compute addresses describe opencode-web-lb-ip \
+      --global --project="$PROJECT_ID" --format='value(address)')
+  fi
+
+  log_info "LB IP: $LB_IP"
+
+  # Idempotent: update existing A record, or create one
+  if gcloud dns record-sets describe "$FQDN" --type=A \
+       --zone="$ZONE_NAME" --project="$DNS_PROJECT" &>/dev/null; then
+    log_info "A record exists; updating to $LB_IP"
+    gcloud dns record-sets update "$FQDN" --type=A --ttl=300 \
+      --rrdatas="$LB_IP" --zone="$ZONE_NAME" --project="$DNS_PROJECT"
+  else
+    log_info "Creating A record"
+    gcloud dns record-sets create "$FQDN" --type=A --ttl=300 \
+      --rrdatas="$LB_IP" --zone="$ZONE_NAME" --project="$DNS_PROJECT"
+  fi
+
+  echo ""
+  log_success "DNS A record set: $FQDN → $LB_IP"
+}
+
+cmd_setup_lb() {
+  log_header "Provisioning LB resources for opencode-web + opencode-login"
+
+  _require_dns_config || return 1
+
+  # Strip trailing dot for SSL cert (cert domains do NOT use trailing dot)
+  CERT_DOMAIN="${FQDN%.}"
+
+  log_info "Project:    $PROJECT_ID"
+  log_info "Region:     $REGION"
+  log_info "FQDN:       $FQDN"
+  log_info "Cert SAN:   $CERT_DOMAIN"
+  echo ""
+
+  # 1) Reserved global IP (cmd_setup_dns may have already created it)
+  if ! gcloud compute addresses describe opencode-web-lb-ip \
+        --global --project="$PROJECT_ID" &>/dev/null; then
+    log_info "Reserving global IP: opencode-web-lb-ip"
+    gcloud compute addresses create opencode-web-lb-ip \
+      --global --project="$PROJECT_ID" --quiet
+  else
+    log_info "Global IP opencode-web-lb-ip already exists"
+  fi
+
+  # 2) Google-managed SSL cert (provisioning is async, takes 10-15 min)
+  if ! gcloud compute ssl-certificates describe opencode-web-cert \
+        --global --project="$PROJECT_ID" &>/dev/null; then
+    log_info "Creating Google-managed SSL cert for $CERT_DOMAIN"
+    gcloud compute ssl-certificates create opencode-web-cert \
+      --domains="$CERT_DOMAIN" \
+      --global --project="$PROJECT_ID" --quiet
+  else
+    log_info "SSL cert opencode-web-cert already exists"
+  fi
+
+  # 3) Serverless NEGs (one per Cloud Run service)
+  for entry in "opencode-web-neg:opencode-web" "opencode-login-neg:opencode-login"; do
+    NEG_NAME="${entry%%:*}"
+    SVC_NAME="${entry##*:}"
+    if ! gcloud compute network-endpoint-groups describe "$NEG_NAME" \
+          --region="$REGION" --project="$PROJECT_ID" &>/dev/null; then
+      log_info "Creating serverless NEG: $NEG_NAME → $SVC_NAME"
+      gcloud compute network-endpoint-groups create "$NEG_NAME" \
+        --region="$REGION" \
+        --network-endpoint-type=serverless \
+        --cloud-run-service="$SVC_NAME" \
+        --project="$PROJECT_ID" --quiet
+    else
+      log_info "NEG $NEG_NAME already exists"
+    fi
+  done
+
+  # 4) Backend services
+  for entry in "opencode-web-backend:opencode-web-neg" "opencode-login-backend:opencode-login-neg"; do
+    BS_NAME="${entry%%:*}"
+    NEG_NAME="${entry##*:}"
+    if ! gcloud compute backend-services describe "$BS_NAME" \
+          --global --project="$PROJECT_ID" &>/dev/null; then
+      log_info "Creating backend service: $BS_NAME"
+      gcloud compute backend-services create "$BS_NAME" \
+        --global \
+        --load-balancing-scheme=EXTERNAL_MANAGED \
+        --project="$PROJECT_ID" --quiet
+      gcloud compute backend-services add-backend "$BS_NAME" \
+        --global \
+        --network-endpoint-group="$NEG_NAME" \
+        --network-endpoint-group-region="$REGION" \
+        --project="$PROJECT_ID" --quiet
+    else
+      log_info "Backend service $BS_NAME already exists"
+    fi
+  done
+
+  # 5) URL map with path-based routing
+  #    /login*       → opencode-login-backend
+  #    /__/auth/*    → opencode-login-backend
+  #    everything else (default) → opencode-web-backend
+  if ! gcloud compute url-maps describe opencode-url-map \
+        --global --project="$PROJECT_ID" &>/dev/null; then
+    log_info "Creating URL map: opencode-url-map"
+    gcloud compute url-maps create opencode-url-map \
+      --default-service=opencode-web-backend \
+      --global --project="$PROJECT_ID" --quiet
+
+    log_info "Adding path matcher (login + auth handlers → opencode-login-backend)"
+    gcloud compute url-maps add-path-matcher opencode-url-map \
+      --path-matcher-name=login-paths \
+      --default-service=opencode-web-backend \
+      --new-hosts="$CERT_DOMAIN" \
+      --backend-service-path-rules="/login=opencode-login-backend,/login/*=opencode-login-backend,/__/auth/*=opencode-login-backend" \
+      --global --project="$PROJECT_ID" --quiet
+  else
+    log_info "URL map opencode-url-map already exists"
+  fi
+
+  # 6) Target HTTPS proxy
+  if ! gcloud compute target-https-proxies describe opencode-https-proxy \
+        --global --project="$PROJECT_ID" &>/dev/null; then
+    log_info "Creating target HTTPS proxy: opencode-https-proxy"
+    gcloud compute target-https-proxies create opencode-https-proxy \
+      --url-map=opencode-url-map \
+      --ssl-certificates=opencode-web-cert \
+      --global --project="$PROJECT_ID" --quiet
+  else
+    log_info "Target HTTPS proxy opencode-https-proxy already exists"
+  fi
+
+  # 7) Global forwarding rule (port 443)
+  if ! gcloud compute forwarding-rules describe opencode-fwd-rule \
+        --global --project="$PROJECT_ID" &>/dev/null; then
+    log_info "Creating forwarding rule: opencode-fwd-rule (443)"
+    gcloud compute forwarding-rules create opencode-fwd-rule \
+      --address=opencode-web-lb-ip \
+      --target-https-proxy=opencode-https-proxy \
+      --ports=443 \
+      --load-balancing-scheme=EXTERNAL_MANAGED \
+      --global --project="$PROJECT_ID" --quiet
+  else
+    log_info "Forwarding rule opencode-fwd-rule already exists"
+  fi
+
+  # 8) Enable IAP on opencode-web-backend ONLY (login backend stays public)
+  log_info "Enabling IAP on opencode-web-backend (login backend stays public)"
+  gcloud iap web enable \
+    --resource-type=backend-services \
+    --service=opencode-web-backend \
+    --project="$PROJECT_ID" 2>/dev/null || log_warn "IAP enable skipped (already enabled or requires manual gcipSettings step)"
+
+  echo ""
+  log_success "LB resources provisioned"
+  echo ""
+  log_info "Next manual step (one-time):"
+  log_info "  Apply IAP gcipSettings YAML for the agent-flow tenantIds pattern."
+  log_info "  See gcip-magiclink-setup.md Phase 4."
+  log_info ""
+  log_info "Then bind users: make cloud-sync-iap-users"
+}
+
+cmd_setup_gcip_magiclink() {
+  log_header "Enabling GCIP email-link sign-in"
+
+  log_info "Project: $PROJECT_ID"
+  echo ""
+
+  ACCESS_TOKEN=$(gcloud auth print-access-token)
+
+  curl -sS -X PATCH \
+    -H "Authorization: Bearer $ACCESS_TOKEN" \
+    -H "x-goog-user-project: $PROJECT_ID" \
+    -H "Content-Type: application/json" \
+    "https://identitytoolkit.googleapis.com/admin/v2/projects/${PROJECT_ID}/config?updateMask=signIn.email" \
+    -d '{"signIn":{"email":{"enabled":true,"passwordRequired":false}}}'
+
+  echo ""
+  log_success "GCIP email-link sign-in enabled in project $PROJECT_ID"
+}
+
+cmd_sync_iap_users() {
+  log_header "Syncing IAP users from config.toml to opencode-web-backend"
+
+  # Parse allowed_users from config.toml using bun + smol-toml
   log_info "Reading allowed_users from config.toml..."
   USERS=$(bun -e "
     const fs = require('fs');
@@ -208,78 +451,105 @@ cmd_sync_users() {
     const users = config.default?.auth?.allowed_users || [];
     console.log(users.join('\n'));
   " 2>/dev/null)
-  
+
   if [[ -z "$USERS" ]]; then
     log_warn "No users found in config.toml [default.auth.allowed_users]"
     return 1
   fi
-  
+
   log_info "Users in config.toml:"
   echo "$USERS" | while read -r user; do
-    echo "  - $user"
+    [[ -n "$user" ]] && echo "  - $user"
   done
   echo ""
-  
-  # Get current IAP bindings
-  log_info "Fetching current IAP bindings..."
-  CURRENT=$(gcloud beta iap web get-iam-policy \
-    --region="$REGION" \
-    --resource-type=cloud-run \
-    --service=opencode-web \
+
+  # Get current bindings on the backend service (NOT cloud-run anymore)
+  log_info "Fetching current IAP bindings on opencode-web-backend..."
+  CURRENT=$(gcloud iap web get-iam-policy \
+    --resource-type=backend-services \
+    --service=opencode-web-backend \
     --project="$PROJECT_ID" \
     --format='json' 2>/dev/null | \
     bun -e "
       const input = require('fs').readFileSync('/dev/stdin', 'utf-8');
       const policy = JSON.parse(input || '{}');
-      const bindings = policy.bindings || [];
-      const accessorBinding = bindings.find(b => b.role === 'roles/iap.httpsResourceAccessor');
-      const members = accessorBinding?.members || [];
-      const users = members
+      const accessor = (policy.bindings || []).find(b =>
+        b.role === 'roles/iap.httpsResourceAccessor');
+      const users = (accessor?.members || [])
         .filter(m => m.startsWith('user:'))
         .map(m => m.replace('user:', ''));
       console.log(users.join('\n'));
     " 2>/dev/null || echo "")
-  
+
   # Add new users
-  log_info "Checking for users to add..."
+  log_info "Adding users present in config.toml..."
   echo "$USERS" | while read -r user; do
     [[ -z "$user" ]] && continue
-    if ! echo "$CURRENT" | grep -q "^${user}$"; then
-      log_info "Adding: $user"
-      gcloud beta iap web add-iam-policy-binding \
+    if ! echo "$CURRENT" | grep -qx "$user"; then
+      log_info "  Adding: $user"
+      gcloud iap web add-iam-policy-binding \
         --member="user:$user" \
         --role=roles/iap.httpsResourceAccessor \
-        --region="$REGION" \
-        --resource-type=cloud-run \
-        --service=opencode-web \
+        --resource-type=backend-services \
+        --service=opencode-web-backend \
         --project="$PROJECT_ID" \
         --quiet 2>/dev/null
     else
-      log_info "Already exists: $user"
+      log_info "  Already exists: $user"
     fi
   done
-  
+
   # Remove users not in config
-  log_info "Checking for users to remove..."
+  log_info "Removing users no longer in config.toml..."
   if [[ -n "$CURRENT" ]]; then
     echo "$CURRENT" | while read -r user; do
       [[ -z "$user" ]] && continue
-      if ! echo "$USERS" | grep -q "^${user}$"; then
-        log_warn "Removing: $user"
-        gcloud beta iap web remove-iam-policy-binding \
+      if ! echo "$USERS" | grep -qx "$user"; then
+        log_warn "  Removing: $user"
+        gcloud iap web remove-iam-policy-binding \
           --member="user:$user" \
           --role=roles/iap.httpsResourceAccessor \
-          --region="$REGION" \
-          --resource-type=cloud-run \
-          --service=opencode-web \
+          --resource-type=backend-services \
+          --service=opencode-web-backend \
           --project="$PROJECT_ID" \
           --quiet 2>/dev/null
       fi
     done
   fi
-  
+
   echo ""
-  log_success "IAP users synced from config.toml"
+  log_success "IAP users synced to opencode-web-backend"
+}
+
+cmd_teardown_lb() {
+  log_header "Tearing down LB resources (DESTRUCTIVE)"
+
+  log_warn "This will REMOVE the LB and BREAK the deployment."
+  log_warn "Cloud DNS records and Cloud Run services are NOT touched."
+  read -r -p "Are you sure? [y/N]: " confirm
+  if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+    log_info "Cancelled"
+    return 0
+  fi
+
+  # Delete in reverse dependency order; ignore errors if resource is absent
+  for cmd in \
+    "gcloud compute forwarding-rules delete opencode-fwd-rule --global --quiet --project=$PROJECT_ID" \
+    "gcloud compute target-https-proxies delete opencode-https-proxy --global --quiet --project=$PROJECT_ID" \
+    "gcloud compute url-maps delete opencode-url-map --global --quiet --project=$PROJECT_ID" \
+    "gcloud iap web disable --resource-type=backend-services --service=opencode-web-backend --project=$PROJECT_ID" \
+    "gcloud compute backend-services delete opencode-web-backend --global --quiet --project=$PROJECT_ID" \
+    "gcloud compute backend-services delete opencode-login-backend --global --quiet --project=$PROJECT_ID" \
+    "gcloud compute network-endpoint-groups delete opencode-web-neg --region=$REGION --quiet --project=$PROJECT_ID" \
+    "gcloud compute network-endpoint-groups delete opencode-login-neg --region=$REGION --quiet --project=$PROJECT_ID" \
+    "gcloud compute ssl-certificates delete opencode-web-cert --global --quiet --project=$PROJECT_ID" \
+    "gcloud compute addresses delete opencode-web-lb-ip --global --quiet --project=$PROJECT_ID"; do
+    log_info "Running: $cmd"
+    eval "$cmd" 2>/dev/null || true
+  done
+
+  echo ""
+  log_success "LB resources removed"
 }
 
 # Main
@@ -302,18 +572,37 @@ case "${1:-}" in
   delete)
     cmd_delete
     ;;
-  sync-users)
-    cmd_sync_users
+  setup-dns)
+    cmd_setup_dns
+    ;;
+  setup-lb)
+    cmd_setup_lb
+    ;;
+  setup-gcip-magiclink)
+    cmd_setup_gcip_magiclink
+    ;;
+  sync-iap-users)
+    cmd_sync_iap_users
+    ;;
+  teardown-lb)
+    cmd_teardown_lb
     ;;
   *)
     show_usage "cloud.sh" "
-  setup              One-time setup (APIs, Artifact Registry, IAM)
-  deploy             Build and deploy to Cloud Run
-  status             Show Cloud Run service status
-  urls               Show service URLs
-  logs [svc]         View logs (default: opencode-web)
-  delete             Delete all Cloud Run services
-  sync-users         Sync IAP allowed users from config.toml
+  setup                  One-time setup (APIs, Artifact Registry, IAM)
+  deploy                 Build and deploy to Cloud Run
+  status                 Show Cloud Run service status
+  urls                   Show service URLs
+  logs [svc]             View logs (default: opencode-web)
+  delete                 Delete all Cloud Run services
+
+  setup-dns              Create cross-project DNS A record from config.toml
+  setup-lb               Provision LB resources (NEGs, backend services,
+                         URL map with path routing, SSL cert, fwd rule)
+  setup-gcip-magiclink   Enable GCIP email-link sign-in in this project
+  sync-iap-users         Sync IAP allowed_users from config.toml to the
+                         opencode-web-backend backend service
+  teardown-lb            DESTRUCTIVE: remove all LB resources
 
 Environment variables:
   GCP_PROJECT  GCP project ID (default: kunal-scratch)


### PR DESCRIPTION
> **Note on rebase (2026-04-24):** This PR was rebased after `main` was reverted
> to commit `826ffacd` (#39, pre-ADK era) plus a cherry-pick of `6312bf66`
> (#50 — LLM model factory). The 4 auth commits below were re-authored on
> top of the new `main` so they no longer carry the OpenCode → ADK migration
> (#41–#58) along with them.
>
> What changed vs. the original PR:
> - The cloudbuild step rename portion (`adk-backend` → `opencode-web` step
>   IDs and image names) was **dropped** from commit 2: at the new `#39`
>   base the cloudbuild already deploys a service named `opencode-web`,
>   so the rename is a no-op and #61 is no longer relevant to this PR.
> - The original commit messages referenced `(#60, #61)` for commit 2;
>   the re-authored commit message references only `(#60)`.
> - All other content is functionally equivalent (same Firebase env var
>   wiring, same magic-link UI, same docs, same `--ingress` and IAP
>   changes).
>
> The pre-rebase state is preserved in:
> - branch `update-to-adk` (= old `main` HEAD `9e0aa51b`)
> - tag   `pre-revert-main-2026-04-24` (immutable, points at `9e0aa51b`)

---

## Summary

Implements the **v1 magic-link migration** described in issue #60 — replaces
Cloud Run direct IAP on `opencode-web` with External LB + IAP at the LB
backend service + GCIP "agent flow" (`tenantIds: ["_<project_number>"]`)
+ magic-link email sign-in. Single subdomain `dcoder.<base_domain>` with
path-based URL-map routing. All in Argolis project `kunal-scratch`.

## Linked issues

- Closes #60 (after deployment + verification)
- Supersedes #59 (closed earlier; cross-project Firebase no longer needed)

## Status

🟡 **Draft** — DNS placeholders in `config.toml` need to be filled in by the
operator before deployment. See `gcip-magiclink-setup.md` Phase 0.

## What's in this PR

Four commits, all under `onchain-agents/coding-labs/`:

1. `feat(cloud): add LB+IAP+GCIP magic-link operational scaffolding`
   - `config.toml` — new `[default.dns]` block (placeholders) + per-service
     `path_prefix(es)` and `iap_enabled` fields.
   - `scripts/cloud.sh` — replaced `cmd_sync_users` with `cmd_sync_iap_users`
     (now binds users on `opencode-web-backend` backend service IAP IAM);
     added `cmd_setup_dns`, `cmd_setup_lb`, `cmd_setup_gcip_magiclink`,
     `cmd_teardown_lb` with shared `_dns_field` / `_require_dns_config`
     helpers. Idempotent create-or-update pattern throughout.
   - `Makefile` — replaced `cloud-sync-users` target with the new targets.

2. `refactor(cloudbuild): drop direct IAP, switch to LB ingress`
   - Dropped `--iap` from the opencode-web deploy step.
   - Dropped the `setup-iap` step entirely (replaced with an explanatory
     NOTE comment).
   - Switched both opencode-web and opencode-login to
     `--ingress=internal-and-cloud-load-balancing`.
   - Added Firebase env vars (`FIREBASE_API_KEY`, `FIREBASE_AUTH_DOMAIN`,
     `FIREBASE_PROJECT_ID`) to the opencode-login deploy via new
     `_FIREBASE_API_KEY` / `_FIREBASE_AUTH_DOMAIN` substitutions.
   - Updated header / step comment blocks to describe the new LB +
     gcipSettings architecture.

3. `feat(opencode-login): magic-link sign-in UI + Firebase email-link handler`
   - `server.js` — extended `/config` endpoint with public Firebase config;
     added explicit `/login` route before static middleware.
   - `public/index.html` — replaced "Sign in with Google" anchor with email
     input + send-link button + 'Check your email' state container; added
     Firebase JS SDK module script (firebase-app + firebase-auth from
     gstatic CDN) calling `sendSignInLinkToEmail`.
   - `public/styles.css` — magic-link UI styles integrated with existing
     dark-theme design system.
   - `public/__/auth/handler.html` (NEW) — Firebase email-link return
     handler. Calls `signInWithEmailLink` then redirects to
     `continueUri`/`state`/`/`.

4. `docs(auth): add gcip-magiclink-setup.md, update READMEs, compose env vars`
   - `gcip-magiclink-setup.md` (NEW) — Phase 0 → Phase 5 setup walkthrough
     covering DNS prerequisites, cross-project IAM grant, Firebase public
     config retrieval, the make-target sequence, and the one-time manual
     `gcloud beta iap settings set` for the gcipSettings YAML (with the
     undocumented agent-flow `tenantIds: ["_<project_number>"]` pattern).
   - `compose.yaml` — Firebase env vars on opencode-login + optional
     `firebase-auth-emulator` service under `profiles: ['emulator']`.
   - `README.md` — updated Detailed Architecture diagram, expanded Cloud
     make-target table, added Firebase env-var rows, added 'Custom domain
     & magic-link auth' section.
   - `packages/opencode-login/README.md` — rewrote architecture diagram,
     env-vars table, endpoints table.
   - `.context.md` — added session 25 entry summarizing the migration.

## Pre-flight validation performed

- ✅ `bash -n scripts/cloud.sh` — syntax OK
- ✅ `node --check packages/opencode-login/server.js` — syntax OK
- ✅ `make help` — runs cleanly, lists all new targets in the Cloud section
- ✅ `python3 -c "import yaml; yaml.safe_load(...)"` — both
  `cloudbuild.yaml` and `compose.yaml` parse as valid YAML
- ✅ `python3 -c "import tomllib; tomllib.load(...)"` — `config.toml` parses
- ✅ `bun -e "const{parse}=require('smol-toml')..."` — `[default.dns]`,
  `[default.services.opencode-web]`, and `[default.services.opencode-login]`
  blocks all parse correctly through the same code path used by `cloud.sh`

## Pre-merge checklist (operator)

- [ ] Fill in `config.toml [default.dns]` with real values
      (`project_id`, `zone_name`, `base_domain`)
- [ ] Grant `roles/dns.recordSetEditor` to the Cloud Build SA + default
      compute SA on the DNS-hosting project (see setup doc Phase 0)
- [ ] Capture `FIREBASE_API_KEY` and `FIREBASE_AUTH_DOMAIN` from the
      Identity Toolkit admin API and pass via Cloud Build substitutions
- [ ] Run `make cloud-setup-gcip-magiclink` to enable email link
- [ ] Run `make cloud-deploy` (now uses LB ingress + Firebase env vars)
- [ ] Run `make cloud-setup-dns` to create the A record
- [ ] Run `make cloud-setup-lb` to provision LB resources
- [ ] Wait for SSL cert to reach ACTIVE (10–15 min after DNS propagates)
- [ ] Apply IAP gcipSettings YAML manually (Phase 4 of setup doc — the
      undocumented `tenantIds: ["_<project_number>"]` agent-flow pattern)
- [ ] Run `make cloud-sync-iap-users` to bind users
- [ ] Verify acceptance criteria 1–12 from issue #60 v1 spec

## Deviations from the spec

- **`scripts/generate-env.ts` was not modified.** Reading the script, it
  generates env vars from `[default.services.*]` and `[default.agents.*]`
  generically, so the new `[default.dns]` section is simply not emitted as
  env vars — which is correct (DNS config is operator-side, consumed by
  `scripts/cloud.sh`, not by container runtimes). The new
  `opencode-web` / `opencode-login` service blocks ARE emitted by the
  generic services loop with their host/port (they have those fields), and
  the `path_prefix(es)` / `iap_enabled` fields are silently ignored by the
  loop's typed projection — no breakage.
- **`cmd_setup_lb` does NOT apply the gcipSettings YAML.** Per the spec
  it's TBD; the function enables IAP on `opencode-web-backend` but the
  YAML application requires the apiKey to be known and is left as a
  one-time manual `gcloud beta iap settings set` step (Phase 4 of the
  setup doc). This is documented in `gcip-magiclink-setup.md` and in the
  `cloud-setup-lb` log output.

## Open issues / TODOs surfaced during implementation

- **IAP+GCIP redirect-back contract** — the `__/auth/handler.html` page
  uses the simple "redirect to original URL" pattern after
  `signInWithEmailLink` succeeds. The spec acknowledged this may need
  extension (POSTing the ID token to an IAP endpoint, or relying on
  Firebase JS SDK session-cookie behaviour when authDomain matches the
  IAP-bound hostname). The simple pattern is implemented first; the
  caveat is documented inline in `handler.html` and in
  `gcip-magiclink-setup.md` 'Open issues'. If verification shows the
  simple pattern is insufficient, follow-up the handler with the
  documented links to https://cloud.google.com/iap/docs/external-identities
  and https://firebase.google.com/docs/auth/web/email-link-auth.

- **`cmd_setup_lb` does not yet apply gcipSettings YAML automatically.**
  Future enhancement: capture apiKey from `setup-gcip-magiclink` output
  (or from Identity Toolkit query) into a state file, then templatize the
  YAML and apply it as part of `setup-lb`.