### PR TITLE
feat(cloud): consolidate Makefile + automate Google sign-in bootstrap

### DIFF
--- a/onchain-agents/coding-labs/.context.md
+++ b/onchain-agents/coding-labs/.context.md
@@ -257,6 +257,46 @@ Sonic is a high-performance EVM-compatible L1 (rebranded from Fantom):
 - **Full end-to-end test via OpenCode web UI** - Test generate → compile → deploy → call → query-state with session persistence
 - **Add session persistence** - Current in-memory session state is lost on container restart
 
+### 2026-04-24 (session 27)
+- **Comprehensive cloud bootstrap consolidation (issue #69):**
+  - Eliminated recurring "manual config band-aid" pattern that plagued
+    IAP+GCIP+Google-OAuth bring-up across PRs #62/#64/#66/#68 and the
+    Google sign-in pivot.
+  - Auto-supplied `_FIREBASE_API_KEY` + `_FIREBASE_AUTH_DOMAIN` substitutions
+    in `cmd_deploy` (was: defaults to `''` in cloudbuild.yaml; reset env vars
+    to empty every deploy).
+  - Replaced stale `cmd_setup_gcip_magiclink` with `cmd_setup_auth` (does
+    Google IdP config + authorizedDomains merge + IAP gcipSettings YAML in
+    one shot).
+  - Codified URL map path rules (added `/config`, `/styles.css`, `/health`;
+    dropped `/__/auth/*`) in `cmd_setup_lb`, with idempotent drift detection
+    so re-running cleanly refreshes stale rules.
+  - Consolidated Makefile from 11 surfaced cloud-* targets to 7 surfaced +
+    4 advanced sub-targets.
+  - Merged `cmd_teardown_lb` + `cmd_delete` into single `cmd_teardown`
+    (single confirmation; LB then Cloud Run services).
+  - Renamed `cmd_setup` → `cmd_setup_project`, `cmd_sync_iap_users` →
+    `cmd_sync_users`. New meta `cmd_setup` chains the four sub-functions.
+  - Added `.env` (gitignored) for `GOOGLE_OAUTH_CLIENT_SECRET`;
+    `config.toml [default.auth.google].client_id` for public client_id.
+  - Added `_load_env`, `_oauth_client_id`, `_oauth_client_secret`,
+    `_deployment_fqdn` helpers.
+- **Operator workflow now:** `make cloud-setup` → `make cloud-deploy` →
+  `make cloud-sync-users`. No manual gcloud follow-ups needed across redeploys.
+- **Files Modified:**
+  - `scripts/cloud.sh` (~80% rewrite)
+  - `Makefile` (cloud-* target reorganization)
+  - `cloudbuild.yaml` (comment-only updates to substitutions header)
+  - `config.toml` (`[default.auth.google]` section added)
+  - `.gitignore` (clarifying comment near `.env` entry)
+  - `gcip-google-signin-setup.md` (rewrite for v3 workflow)
+  - `README.md` (operator workflow + cloud target table)
+- **Files Created:**
+  - `.env.example`
+- **Resolves:** GitHub issue #69
+- **Folds in / supersedes (not separately filed):** Issues B, C, D refined,
+  K, L (per issue #69 body).
+
 ### 2026-04-24 (session 26)
 - **Pivoted opencode-login from email-link to Google sign-in (issue #67):**
   - Email-link sign-in via GCIP was end-to-end broken: Firebase backend bug

--- a/onchain-agents/coding-labs/.env.example
+++ b/onchain-agents/coding-labs/.env.example
@@ -1,0 +1,12 @@
+# Local environment variables for cloud setup. Copy to .env (gitignored)
+# and fill in your values.
+#
+# .env is sourced by scripts/cloud.sh's _load_env helper before
+# operations that need these values.
+
+# Google OAuth Web Client secret. Pair with client_id in
+# config.toml [default.auth.google].
+# Get from: https://console.cloud.google.com/apis/credentials in your
+# non-Argolis project where the OAuth Web Client was created.
+# See gcip-google-signin-setup.md Phase 1.
+GOOGLE_OAUTH_CLIENT_SECRET=GOCSPX-...

--- a/onchain-agents/coding-labs/.gitignore
+++ b/onchain-agents/coding-labs/.gitignore
@@ -8,6 +8,8 @@ build/
 *.tsbuildinfo
 
 # Environment
+# .env holds local secrets sourced by scripts/cloud.sh (e.g.
+# GOOGLE_OAUTH_CLIENT_SECRET). Use .env.example as the committed template.
 .env
 .env.local
 .env.*.local

--- a/onchain-agents/coding-labs/Makefile
+++ b/onchain-agents/coding-labs/Makefile
@@ -5,9 +5,9 @@
 .PHONY: help install clean build test run dev lint \
         container-clean container-build container-run container-stop container-logs \
         up down rebuild logs \
-        cloud-setup cloud-deploy cloud-status cloud-urls cloud-logs cloud-delete \
-        cloud-setup-dns cloud-setup-lb cloud-setup-gcip-magiclink \
-        cloud-sync-iap-users cloud-teardown-lb \
+        cloud-setup cloud-deploy cloud-sync-users \
+        cloud-status cloud-urls cloud-logs cloud-teardown \
+        cloud-setup-project cloud-setup-dns cloud-setup-lb cloud-setup-auth \
         config health send
 
 .DEFAULT_GOAL := help
@@ -63,14 +63,21 @@ logs: container-logs ## View logs (alias)
 rebuild: container-build container-run ## Build and start containers
 
 # =============================================================================
-# CLOUD (Cloud Run)
+# CLOUD (Cloud Run + LB + IAP + GCIP)
 # =============================================================================
+# Operator workflow:
+#   1. make cloud-setup       (one-time bootstrap: project + DNS + LB + auth)
+#   2. make cloud-deploy      (build + deploy services; auto Firebase substitutions)
+#   3. make cloud-sync-users  (bind allowed_users from config.toml to IAP IAM)
 
-cloud-setup: ## One-time cloud infrastructure setup
+cloud-setup: ## One-time bootstrap (project + DNS + LB + auth)
 	@./scripts/cloud.sh setup
 
-cloud-deploy: ## Build and deploy to Cloud Run
+cloud-deploy: ## Build + deploy services (auto-supplies Firebase substitutions)
 	@./scripts/cloud.sh deploy
+
+cloud-sync-users: ## Sync allowed_users from config.toml to IAP IAM
+	@./scripts/cloud.sh sync-users
 
 cloud-status: ## Show Cloud Run service status
 	@./scripts/cloud.sh status
@@ -81,23 +88,21 @@ cloud-urls: ## Show Cloud Run service URLs
 cloud-logs: ## View Cloud Run logs (SVC=service-name)
 	@./scripts/cloud.sh logs $(SVC)
 
-cloud-delete: ## Delete all Cloud Run services
-	@./scripts/cloud.sh delete
+cloud-teardown: ## DESTRUCTIVE: Tear down all infrastructure (LB + Cloud Run services)
+	@./scripts/cloud.sh teardown
 
-cloud-setup-dns: ## Set up cross-project DNS A record from config.toml
+# Advanced sub-targets (called by cloud-setup; useful for recovery)
+cloud-setup-project: ## (advanced) Project APIs + IAM only
+	@./scripts/cloud.sh setup-project
+
+cloud-setup-dns: ## (advanced) Cross-project DNS A record only
 	@./scripts/cloud.sh setup-dns
 
-cloud-setup-lb: ## Provision LB resources (URL map, backend services, NEGs, cert)
+cloud-setup-lb: ## (advanced) LB resources + URL map + IAP enable
 	@./scripts/cloud.sh setup-lb
 
-cloud-setup-gcip-magiclink: ## Enable GCIP email-link sign-in in this project
-	@./scripts/cloud.sh setup-gcip-magiclink
-
-cloud-sync-iap-users: ## Sync IAP allowed_users from config.toml to opencode-web-backend
-	@./scripts/cloud.sh sync-iap-users
-
-cloud-teardown-lb: ## DESTRUCTIVE: tear down LB resources
-	@./scripts/cloud.sh teardown-lb
+cloud-setup-auth: ## (advanced) GCIP Google IdP + authorizedDomains + IAP gcipSettings
+	@./scripts/cloud.sh setup-auth
 
 # =============================================================================
 # UTILITIES
@@ -121,28 +126,26 @@ help: ## Show this help
 	@echo ""
 	@echo "Usage: make <target>"
 	@echo ""
-	@echo "Cloud setup (one-time, in order):"
-	@echo "  1. make cloud-setup                  # Enable APIs, grant project IAM,"
-	@echo "                                       # grant cross-project DNS IAM (if configured)"
-	@echo "  2. make cloud-setup-gcip-magiclink   # Enable email-link sign-in,"
-	@echo "                                       # emit Firebase config for substitutions"
-	@echo "  3. make cloud-deploy                 # Build + deploy Cloud Run services"
-	@echo "  4. make cloud-setup-dns              # Create cross-project DNS A record"
-	@echo "  5. make cloud-setup-lb               # Provision LB + IAP + cert"
-	@echo "  6. (manual) Apply IAP gcipSettings YAML — see gcip-magiclink-setup.md Phase 4"
-	@echo "  7. make cloud-sync-iap-users         # Bind users from config.toml"
+	@echo "Cloud workflow (3 commands; no manual gcloud follow-ups):"
+	@echo "  1. make cloud-setup        # One-time bootstrap (project + DNS + LB + auth)"
+	@echo "  2. make cloud-deploy       # Build + deploy services (auto Firebase config)"
+	@echo "  3. make cloud-sync-users   # Bind allowed_users from config.toml to IAP IAM"
+	@echo ""
+	@echo "Pre-setup: fill config.toml [default.dns] + [default.auth.google].client_id,"
+	@echo "and copy .env.example to .env with GOOGLE_OAUTH_CLIENT_SECRET. See"
+	@echo "gcip-google-signin-setup.md for the full operator flow."
 	@echo ""
 	@echo "Local:"
-	@grep -E '^(install|clean|build|test|run|dev|lint):.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^(install|clean|build|test|run|dev|lint):.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Container:"
-	@grep -E '^(container-[a-z]+|up|down|logs|rebuild):.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^(container-[a-z]+|up|down|logs|rebuild):.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Cloud:"
-	@grep -E '^cloud-.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^cloud-.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Utilities:"
-	@grep -E '^(config|health|send):.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^(config|health|send):.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Examples:"
 	@echo "  make run                    # Start all services locally"

--- a/onchain-agents/coding-labs/README.md
+++ b/onchain-agents/coding-labs/README.md
@@ -346,19 +346,32 @@ make help  # Show all available targets
 | `container-clean` | Remove containers and images |
 
 #### Cloud
+
+Operator workflow (3 commands; no manual gcloud follow-ups across redeploys):
+
+```bash
+make cloud-setup         # One-time bootstrap: project + DNS + LB + auth
+make cloud-deploy        # Build + deploy services (auto Firebase substitutions)
+make cloud-sync-users    # Bind allowed_users from config.toml to IAP IAM
+```
+
+See [`gcip-google-signin-setup.md`](./gcip-google-signin-setup.md) for the
+one-time pre-setup steps (OAuth client in non-Argolis project, populating
+`config.toml` and `.env`).
+
 | Target | Description |
 |--------|-------------|
-| `cloud-setup` | One-time cloud infrastructure setup |
-| `cloud-deploy` | Deploy all services to Cloud Run |
+| `cloud-setup` | One-time bootstrap (project + DNS + LB + auth) |
+| `cloud-deploy` | Build + deploy services (auto-supplies Firebase substitutions) |
+| `cloud-sync-users` | Sync `allowed_users` from `config.toml` to IAP IAM |
 | `cloud-status` | Show Cloud Run service status |
 | `cloud-urls` | Print Cloud Run service URLs |
 | `cloud-logs SVC=<name>` | View Cloud Run logs |
-| `cloud-delete` | Delete all Cloud Run services |
-| `cloud-setup-dns` | Create cross-project DNS A record from `config.toml` |
-| `cloud-setup-lb` | Provision LB resources (NEGs, backend services, URL map, cert) |
-| `cloud-setup-gcip-magiclink` | (Legacy/unused) Enable GCIP email-link sign-in — superseded by Google sign-in (#67); see `gcip-google-signin-setup.md` |
-| `cloud-sync-iap-users` | Sync IAP allowed users from `config.toml` to `opencode-web-backend` |
-| `cloud-teardown-lb` | DESTRUCTIVE: tear down LB resources |
+| `cloud-teardown` | DESTRUCTIVE: tear down all infrastructure (LB + Cloud Run services) |
+| `cloud-setup-project` | (advanced) Project APIs + IAM only |
+| `cloud-setup-dns` | (advanced) Cross-project DNS A record from `config.toml` |
+| `cloud-setup-lb` | (advanced) LB resources (NEGs, backend services, URL map, cert) |
+| `cloud-setup-auth` | (advanced) GCIP Google IdP + authorizedDomains + IAP gcipSettings |
 
 #### Utilities
 | Target | Description |

--- a/onchain-agents/coding-labs/cloudbuild.yaml
+++ b/onchain-agents/coding-labs/cloudbuild.yaml
@@ -15,21 +15,20 @@
 # Services:
 #   - midnight-node, midnight-indexer, midnight-proof-server: Public (Midnight infra)
 #   - agent-registry, somnia-agent, midnight-agent, midnight-mcp: Public (no auth)
-#   - opencode-login: LB-only, no auth (renders the magic-link sign-in page)
+#   - opencode-login: LB-only, no auth (renders the Google sign-in page)
 #   - opencode-web:   LB-only, IAP via gcipSettings agent flow at backend
 #                     service layer (NOT direct Cloud Run --iap)
 #
-# Authentication architecture (issue #60):
+# Authentication architecture (issues #60 + #67 + #69):
 #   External Application LB + IAP at LB backend service + GCIP "agent flow"
-#   + magic-link email sign-in. See gcip-magiclink-setup.md.
+#   + Google sign-in via cross-project OAuth client. See
+#   gcip-google-signin-setup.md.
 #
-#   The LB resources, IAP enablement, gcipSettings YAML, and IAP IAM bindings
-#   are NOT provisioned by this pipeline. They are managed by:
-#     make cloud-setup-dns
-#     make cloud-setup-lb
-#     make cloud-setup-gcip-magiclink
-#     make cloud-sync-iap-users
-#   plus a one-time manual `gcloud beta iap settings set` for gcipSettings.
+#   The LB resources, IAP enablement, gcipSettings YAML, GCIP Google IdP
+#   config, and IAP IAM bindings are NOT provisioned by this pipeline. They
+#   are managed by (issue #69 consolidation):
+#     make cloud-setup        # one-time: project + DNS + LB + auth
+#     make cloud-sync-users   # bind allowed_users from config.toml
 #
 # Midnight Infrastructure Versions:
 #   - Node: 0.20.1
@@ -963,15 +962,13 @@ steps:
 # -----------------------------------------------------------------------------
 # Substitutions
 # -----------------------------------------------------------------------------
-# _FIREBASE_API_KEY and _FIREBASE_AUTH_DOMAIN are PUBLIC Firebase config values
-# used by opencode-login to render the magic-link sign-in UI.
+# _FIREBASE_API_KEY and _FIREBASE_AUTH_DOMAIN are auto-supplied by
+# `make cloud-deploy` from the Identity Toolkit Admin API. No manual
+# substitution needed.
 #
-# Get current values by running: make cloud-setup-gcip-magiclink
-# (it emits the substitution flags ready to copy-paste).
-#
-# Example invocation:
-#   gcloud builds submit \
-#     --substitutions=_FIREBASE_API_KEY=$_FIREBASE_API_KEY,_FIREBASE_AUTH_DOMAIN=$_FIREBASE_AUTH_DOMAIN,_FIREBASE_PROJECT_ID=$_FIREBASE_PROJECT_ID,...
+# These values are used by opencode-login to render the Google sign-in UI
+# via Firebase JS SDK. They are PUBLIC by Firebase design (security comes
+# from authorizedDomains + Security Rules, not from secrecy of the apiKey).
 substitutions:
   _REGION: us-central1
   _REPO: coding-labs

--- a/onchain-agents/coding-labs/config.toml
+++ b/onchain-agents/coding-labs/config.toml
@@ -304,13 +304,13 @@ default_agents = ["somnia", "sonic", "midnight", "store", "payment", "security"]
 # The DNS zone lives in a separate Argolis project; the Cloud Build SA must
 # have roles/dns.recordSetEditor on that project.
 #
-# Workflow:
+# Workflow (issue #69 consolidation):
 #   1. Fill in placeholders below with actual values
-#   2. Grant cross-project IAM (see gcip-magiclink-setup.md)
-#   3. Run: make cloud-setup-gcip-magiclink
-#   4. Run: make cloud-setup-dns
-#   5. Run: make cloud-setup-lb
-#   6. Run: make cloud-sync-iap-users
+#   2. Fill in [default.auth.google].client_id (see gcip-google-signin-setup.md
+#      Phase 0) and copy .env.example to .env with GOOGLE_OAUTH_CLIENT_SECRET
+#   3. Run: make cloud-setup       # one-time: project + DNS + LB + auth
+#   4. Run: make cloud-deploy
+#   5. Run: make cloud-sync-users  # bind allowed_users to IAP IAM
 
 [default.dns]
 # Argolis project hosting the Cloud DNS managed zone (cross-project)
@@ -337,13 +337,30 @@ subdomain = "dcoder"
 #
 # Workflow:
 #   1. Add/remove emails from allowed_users list
-#   2. Run: make cloud-sync-iap-users    # Sync IAP bindings on backend service
+#   2. Run: make cloud-sync-users        # Sync IAP bindings on backend service
 #   3. Changes take effect immediately
 
 [default.auth]
 allowed_users = [
   "admin@kunall.altostrat.com",
 ]
+
+# =============================================================================
+# Google OAuth (cross-project bridge for GCIP Google IdP)
+# =============================================================================
+# The Google OAuth Web Client must be created in a non-Argolis project
+# (Argolis projects lock the OAuth Consent Screen to User Type: Internal).
+# See gcip-google-signin-setup.md Phase 1 for setup.
+#
+# client_id is PUBLIC by Google's design (it's an identifier, not a secret) —
+# safe to commit. Security comes from the redirect URI whitelist on the OAuth
+# client itself.
+#
+# client_secret is sensitive — store in .env (gitignored), NOT here.
+# See .env.example for the template.
+
+[default.auth.google]
+client_id = "<GOOGLE_OAUTH_CLIENT_ID>"  # e.g. 954632890046-...apps.googleusercontent.com
 
 # =============================================================================
 # PRODUCTION OVERRIDES

--- a/onchain-agents/coding-labs/gcip-google-signin-setup.md
+++ b/onchain-agents/coding-labs/gcip-google-signin-setup.md
@@ -1,9 +1,15 @@
-# GCIP Google Sign-In Setup (v2)
+# GCIP Google Sign-In Setup (v3 — fully automated)
 
 This document covers the operator-side setup for Google sign-in via the
-LB+IAP+GCIP architecture. Replaces the abandoned email-link approach
-(`gcip-magiclink-setup.md`) due to a Firebase backend bug for
-`IDENTITY_PLATFORM` subtype projects.
+LB+IAP+GCIP architecture. Replaces the manual Phase-by-Phase walkthroughs
+of v1 (magic-link, abandoned per issue #67) and v2 (manual GCIP IdP setup,
+consolidated in issue #69).
+
+After issue #69 lands, all GCIP/IAP/LB configuration that used to be a
+separate manual `curl`/`gcloud` invocation is automated by `scripts/cloud.sh`.
+The operator only needs to populate two configuration values once
+(`config.toml [default.auth.google].client_id` + `.env` `GOOGLE_OAUTH_CLIENT_SECRET`)
+and then run three `make` commands.
 
 ## Architecture
 
@@ -26,14 +32,29 @@ LB+IAP+GCIP architecture. Replaces the abandoned email-link approach
                            User redirected to protected app, signed in
 ```
 
-## One-Time Setup
+## Operator Workflow After Issue #69
 
-### Phase 1 — Provision OAuth Client in non-Argolis project (~10 min)
+```bash
+# One-time per environment
+make cloud-setup        # Bootstraps project + DNS + LB + auth (chains 4 sub-targets)
+make cloud-deploy       # Build + deploy services (auto-supplies Firebase substitutions)
+make cloud-sync-users   # Bind whitelist from config.toml to IAP IAM
 
-The Google OAuth Web Client must come from a project where the OAuth Consent
-Screen has User Type: **External**. Argolis projects (`*.altostrat.com` org)
-lock User Type to **Internal**. Therefore, use a non-Argolis Google account
-or project.
+# Recurring as needed
+make cloud-deploy       # Re-deploy code; no manual env-var fixes needed
+make cloud-sync-users   # When whitelist changes
+```
+
+## One-Time Pre-Setup Steps
+
+Before running `make cloud-setup`, complete these in order.
+
+### Phase 0 — Create Google OAuth client in non-Argolis project (~10 min)
+
+The Google OAuth Web Client must come from a project where the OAuth
+Consent Screen has User Type: **External**. Argolis projects (`*.altostrat.com`
+org) lock User Type to **Internal**. Therefore, use a non-Argolis Google
+account or project.
 
 **Steps:**
 
@@ -52,53 +73,80 @@ or project.
    - Application type: **Web application**
    - Name: `dCoder GCIP Bridge`
    - Authorized JavaScript origins: `https://kunal-scratch.firebaseapp.com`
+     (substitute your IAP project's firebaseapp.com domain)
    - Authorized redirect URI: `https://kunal-scratch.firebaseapp.com/__/auth/handler`
-5. Capture **Client ID** and **Client Secret** (paste into Phase 2)
+5. Capture **Client ID** and **Client Secret** (used in Phase 1)
 
-### Phase 2 — Configure Google IdP in GCIP (~30 sec)
+### Phase 1 — Populate `config.toml` + `.env`
 
-```bash
-ACCESS_TOKEN=$(gcloud auth print-access-token)
-curl -X POST \
-  -H "Authorization: Bearer $ACCESS_TOKEN" \
-  -H "x-goog-user-project: kunal-scratch" \
-  -H "Content-Type: application/json" \
-  "https://identitytoolkit.googleapis.com/admin/v2/projects/kunal-scratch/defaultSupportedIdpConfigs?idpId=google.com" \
-  -d '{
-    "enabled": true,
-    "clientId": "<CLIENT_ID_FROM_PHASE_1>",
-    "clientSecret": "<CLIENT_SECRET_FROM_PHASE_1>"
-  }'
-```
+Edit `onchain-agents/coding-labs/config.toml`:
 
-Verify:
+- `[default.dns]` — `project_id`, `zone_name`, `base_domain`, `subdomain`
+  (cross-project DNS managed zone)
+- `[default.auth].allowed_users` — list of emails for IAP IAM
+- `[default.auth.google].client_id` — paste the OAuth Client ID from Phase 0
 
-```bash
-ACCESS_TOKEN=$(gcloud auth print-access-token)
-curl -sH "Authorization: Bearer $ACCESS_TOKEN" \
-  -H "x-goog-user-project: kunal-scratch" \
-  "https://identitytoolkit.googleapis.com/admin/v2/projects/kunal-scratch/defaultSupportedIdpConfigs/google.com"
-```
+Copy `.env.example` to `.env` and fill in:
 
-Expected: `enabled: true`, `clientId: <client-id>`, no secret in response.
+- `GOOGLE_OAUTH_CLIENT_SECRET` — paste the OAuth Client Secret from Phase 0
 
-### Phase 3 — Deploy `opencode-login`
+`.env` is gitignored; `client_id` is public-by-design and safe to commit.
+
+### Phase 2 — Cross-project DNS IAM grant
+
+If the DNS zone lives in a separate project (typical for Argolis demos), the
+DNS project owner must grant `roles/dns.recordSetEditor` on the DNS project to
+both Cloud Build SAs in the IAP project. `make cloud-setup-project` (called
+internally by `make cloud-setup`) attempts this and emits the manual `gcloud`
+commands to share with the DNS owner if it lacks permission.
+
+### Phase 3 — Run the bootstrap
 
 ```bash
-make cloud-deploy
+make cloud-setup        # ~15 min (LB cert provisioning takes 10 min)
+make cloud-deploy       # ~15 min (full multi-service Cloud Build pipeline)
+make cloud-sync-users   # ~30 sec
 ```
 
-(or just opencode-login if granular target exists)
+`make cloud-setup` chains:
 
-### Phase 4 — Verify end-to-end
+1. `cloud-setup-project` — APIs + project IAM (idempotent)
+2. `cloud-setup-dns` — Cross-project A record from `[default.dns]`
+3. `cloud-setup-lb` — NEGs + backend services + URL map + cert + IAP enable
+4. `cloud-setup-auth` — Google IdP + authorizedDomains merge + IAP gcipSettings
 
-1. Open `https://dcoder.kunall.demo.altostrat.com/` in incognito
-2. IAP redirects to /login → "Sign in with Google" button visible
-3. Click button → Google account picker popup appears
-4. Sign in with a Google account that's in `config.toml allowed_users`
+Each sub-target is also runnable individually for surgical recovery, e.g.,
+if the LB cert needs to be re-provisioned: `make cloud-setup-lb`.
+
+`make cloud-deploy` auto-fetches the current Firebase apiKey from the
+Identity Toolkit Admin API and passes it as `_FIREBASE_API_KEY` /
+`_FIREBASE_AUTH_DOMAIN` Cloud Build substitutions. No manual `--substitutions`
+flag is needed.
+
+## Verification
+
+After bootstrap completes, visit `https://<subdomain>.<base_domain>` (e.g.,
+`https://dcoder.kunall.demo.altostrat.com`):
+
+1. IAP redirects to `/login`
+2. "Sign in with Google" button visible
+3. Click → Google account picker popup
+4. Sign in with a Google account that's in `[default.auth].allowed_users`
 5. Popup closes, redirected to protected app, signed in
 
-## Why the Cross-Project OAuth Client?
+## Rollback
+
+```bash
+make cloud-teardown   # DESTRUCTIVE; removes all LB resources + Cloud Run services
+```
+
+(Cloud DNS records and the Artifact Registry repo are NOT touched.)
+
+---
+
+## Background
+
+### Why the cross-project OAuth client?
 
 Google OAuth credentials require the OAuth Consent Screen to have User Type:
 External. Argolis projects (`kunall.altostrat.com` org) lock the User Type
@@ -109,7 +157,7 @@ project.
 The cross-project dependency is a single Web OAuth client credential — much
 smaller than maintaining a full Firebase Auth tenant in another project.
 
-## What Was Wrong with Email-Link Sign-In?
+### What was wrong with email-link sign-in (v1)?
 
 We initially tried email-link sign-in (the magic-link approach). After
 extensive debugging, we identified a Firebase backend bug for
@@ -121,20 +169,29 @@ verify / change email templates are exposed), and tenant-level config is
 gated for IDENTITY_PLATFORM projects. We pivoted to Google sign-in as the
 unblock. See issue #67 for the full investigation.
 
-## Rollback
+### Why consolidate (v3, issue #69)?
 
-To revert to email-link (not recommended due to the Firebase bug):
+After v2 (Google sign-in pivot), the operator workflow still required several
+manual `curl` and `gcloud` invocations for:
 
-1. `git revert` the PR that landed this change
-2. Run `make cloud-deploy`
-3. Live with the broken email links until Firebase fixes the bug
+- POSTing the Google IdP config to GCIP
+- Merging `authorizedDomains` (preserving Firebase defaults)
+- Applying the IAP `gcipSettings` YAML
+- Re-supplying `_FIREBASE_API_KEY` substitutions on every deploy
+- Patching the URL map path rules after handler.html was removed
+
+Each manual step regressed on the next `make cloud-deploy`. Issue #69
+codified all of these into `scripts/cloud.sh` so the operator never has to
+reach for raw `gcloud`/`curl` again.
 
 ---
 
 ## Related
 
-- Issue #67 — Pivot to Google sign-in (this work)
-- Issue #60 — Original LB+IAP+GCIP magic-link migration (superseded by #67 for
-  the IdP choice; LB+IAP+GCIP plumbing remains as configured)
+- Issue #69 — Consolidation (this rewrite)
+- Issue #67 — Pivot to Google sign-in
+- Issue #60 — Original LB+IAP+GCIP magic-link migration (LB plumbing remains;
+  IdP changed to Google)
 - PR #62 — LB+IAP+GCIP magic-link implementation
 - PR #64 — Bootstrap LB+IAP+GCIP prerequisites + Firebase config emission
+- PR #68 — Switch from email-link to Google OAuth (handler.html removed)

--- a/onchain-agents/coding-labs/scripts/cloud.sh
+++ b/onchain-agents/coding-labs/scripts/cloud.sh
@@ -42,7 +42,7 @@ _dns_field() {
     const fs = require('fs');
     const { parse } = require('smol-toml');
     const config = parse(fs.readFileSync('config.toml', 'utf-8'));
-    console.log(config.default?.dns?.${1} || '');
+    console.log(config.default?.dns?.['$1'] || '');
   " 2>/dev/null
 }
 
@@ -299,8 +299,15 @@ cmd_deploy() {
   auth_domain="${PROJECT_ID}.firebaseapp.com"
 
   if [[ -z "$api_key" ]]; then
-    log_warn "Firebase apiKey unavailable; opencode-login will deploy with empty FIREBASE_API_KEY env var."
-    log_warn "Run 'make cloud-setup-auth' first to ensure GCIP is configured."
+    log_error "Firebase apiKey unavailable from Identity Toolkit Admin API."
+    log_error "This would deploy opencode-login with an empty FIREBASE_API_KEY env var,"
+    log_error "causing the sign-in UI to show 'Sign-in is not configured'."
+    log_error ""
+    log_error "Fix: ensure GCIP is initialized for project ${PROJECT_ID}."
+    log_error "Run: make cloud-setup-auth"
+    log_error ""
+    log_error "Aborting deploy to prevent silent failure."
+    return 1
   fi
 
   log_info "Submitting build to Cloud Build..."
@@ -622,47 +629,117 @@ cmd_setup_auth() {
   access_token=$(gcloud auth print-access-token 2>/dev/null)
 
   # === 1. Configure Google IdP (POST first; if 409/400, PATCH) ===
+  # Fix #1: write client_secret to a chmod 600 temp file and pass via --data @file
+  # so the secret is never visible in `ps` or `set -x` traces.
+  # Fix #2: explicit error handling for non-2xx/non-409 responses (no silent success).
   log_info "Configuring Google IdP in GCIP..."
-  local http_code
+  local http_code body_file
+  body_file=$(mktemp)
+  chmod 600 "$body_file"
+  cat > "$body_file" <<EOF_BODY
+{"enabled":true,"clientId":"$client_id","clientSecret":"$client_secret"}
+EOF_BODY
+
   http_code=$(curl -s -o /tmp/gcip_idp_resp.json -w "%{http_code}" \
     -X POST -H "Authorization: Bearer $access_token" \
     -H "x-goog-user-project: $PROJECT_ID" \
     -H "Content-Type: application/json" \
     "https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT_ID/defaultSupportedIdpConfigs?idpId=google.com" \
-    -d "{\"enabled\":true,\"clientId\":\"$client_id\",\"clientSecret\":\"$client_secret\"}")
+    --data @"$body_file")
+  rm -f "$body_file"
 
-  if [[ "$http_code" =~ ^(409|400)$ ]]; then
-    log_info "  Already exists; PATCHing..."
-    curl -sX PATCH -H "Authorization: Bearer $access_token" \
-      -H "x-goog-user-project: $PROJECT_ID" \
-      -H "Content-Type: application/json" \
-      "https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT_ID/defaultSupportedIdpConfigs/google.com?updateMask=enabled,clientId,clientSecret" \
-      -d "{\"enabled\":true,\"clientId\":\"$client_id\",\"clientSecret\":\"$client_secret\"}" \
-      > /dev/null
-  fi
-  log_success "Google IdP configured"
+  case "$http_code" in
+    2*)
+      log_success "Google IdP created"
+      ;;
+    409|400)
+      log_info "  Already exists; PATCHing..."
+      local patch_body_file
+      patch_body_file=$(mktemp)
+      chmod 600 "$patch_body_file"
+      cat > "$patch_body_file" <<EOF_BODY
+{"enabled":true,"clientId":"$client_id","clientSecret":"$client_secret"}
+EOF_BODY
+      curl -sX PATCH -H "Authorization: Bearer $access_token" \
+        -H "x-goog-user-project: $PROJECT_ID" \
+        -H "Content-Type: application/json" \
+        "https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT_ID/defaultSupportedIdpConfigs/google.com?updateMask=enabled,clientId,clientSecret" \
+        --data @"$patch_body_file" \
+        > /dev/null
+      rm -f "$patch_body_file"
+      log_success "Google IdP updated"
+      ;;
+    *)
+      log_error "Unexpected HTTP $http_code from Identity Toolkit Admin API."
+      log_error "Response body:"
+      cat /tmp/gcip_idp_resp.json | head -c 500 >&2
+      echo "" >&2
+      return 1
+      ;;
+  esac
 
   # === 2. authorizedDomains merge ===
+  # Fix #3: validate the GET response and parsed array before computing the merge.
+  # If parsing fails or yields a non-array, refuse to PATCH — sending null/[] would
+  # wipe required defaults (localhost, *.firebaseapp.com, *.web.app) and break sign-in.
   log_info "Syncing authorizedDomains (preserving defaults + adding $deployment_fqdn)..."
-  local current_domains merged
-  current_domains=$(curl -sH "Authorization: Bearer $access_token" \
+  local current_domains merged config_response
+  config_response=$(curl -sH "Authorization: Bearer $access_token" \
     -H "x-goog-user-project: $PROJECT_ID" \
-    "https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT_ID/config" \
-    | bun -e "
+    "https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT_ID/config" 2>/dev/null)
+
+  if [[ -z "$config_response" ]]; then
+    log_error "Failed to fetch project config from Identity Toolkit Admin API"
+    return 1
+  fi
+
+  current_domains=$(echo "$config_response" | bun -e "
+    try {
       const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
-      console.log(JSON.stringify(data.authorizedDomains || []));
-    ")
+      const ad = data.authorizedDomains;
+      if (!Array.isArray(ad)) {
+        console.error('authorizedDomains is not an array');
+        process.exit(1);
+      }
+      console.log(JSON.stringify(ad));
+    } catch (e) {
+      console.error('Failed to parse config response:', e.message);
+      process.exit(1);
+    }
+  " 2>/tmp/cmd_setup_auth_parse_err)
+
+  if [[ $? -ne 0 || -z "$current_domains" ]]; then
+    log_error "Failed to parse authorizedDomains from config response."
+    log_error "Parse error: $(cat /tmp/cmd_setup_auth_parse_err 2>/dev/null)"
+    log_error "Refusing to PATCH (would risk wiping defaults)."
+    return 1
+  fi
+
   merged=$(echo "$current_domains" | bun -e "
     const cur = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
     const required = ['localhost', '${PROJECT_ID}.firebaseapp.com', '${PROJECT_ID}.web.app', '$deployment_fqdn'];
     const merged = [...new Set([...cur, ...required])];
     console.log(JSON.stringify(merged));
   ")
+
+  # Final safety check: merged must contain required defaults before PATCHing.
+  if ! echo "$merged" | grep -q "localhost" || ! echo "$merged" | grep -q "${PROJECT_ID}.firebaseapp.com"; then
+    log_error "Merged authorizedDomains is missing required defaults; refusing to PATCH."
+    log_error "Computed merged: $merged"
+    return 1
+  fi
+
+  # Fix #1 (also): write JSON body to chmod 600 temp file, pass via --data @file.
+  local domains_body
+  domains_body=$(mktemp)
+  chmod 600 "$domains_body"
+  echo "{\"authorizedDomains\":$merged}" > "$domains_body"
   curl -sX PATCH -H "Authorization: Bearer $access_token" \
     -H "x-goog-user-project: $PROJECT_ID" \
     -H "Content-Type: application/json" \
     "https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT_ID/config?updateMask=authorizedDomains" \
-    -d "{\"authorizedDomains\":$merged}" > /dev/null
+    --data @"$domains_body" > /dev/null
+  rm -f "$domains_body"
   log_success "authorizedDomains synced: $merged"
 
   # === 3. IAP gcipSettings (agent-flow YAML) ===
@@ -685,6 +762,7 @@ cmd_setup_auth() {
   fi
   login_url="https://${deployment_fqdn}/login?apiKey=${api_key}"
   tmp_yaml=$(mktemp)
+  chmod 600 "$tmp_yaml"
   cat > "$tmp_yaml" <<EOF
 accessSettings:
   gcipSettings:

--- a/onchain-agents/coding-labs/scripts/cloud.sh
+++ b/onchain-agents/coding-labs/scripts/cloud.sh
@@ -1,13 +1,29 @@
 #!/usr/bin/env bash
-# Cloud deployment operations for Cloud Run
+# Cloud deployment operations for Cloud Run + LB + IAP + GCIP
 #
-# Commands:
-#   setup   - One-time setup (APIs, Artifact Registry, IAM)
-#   deploy  - Build and deploy to Cloud Run
-#   status  - Show Cloud Run service status
-#   urls    - Show service URLs
-#   logs    - View logs (default: opencode-web)
-#   delete  - Delete all Cloud Run services
+# Operator workflow (one-time per environment):
+#   1. make cloud-setup       (bootstraps project + DNS + LB + auth)
+#   2. make cloud-deploy      (build + deploy services; auto Firebase substitutions)
+#   3. make cloud-sync-users  (bind allowed_users from config.toml to IAP IAM)
+#
+# Recurring:
+#   make cloud-deploy         (re-deploy code; no manual env-var fixes needed)
+#   make cloud-sync-users     (when allowed_users changes)
+#
+# Commands (top-level):
+#   setup            One-time meta bootstrap (project + dns + lb + auth)
+#   deploy           Build and deploy to Cloud Run (auto Firebase substitutions)
+#   status           Show Cloud Run service status
+#   urls             Show service URLs
+#   logs [svc]       View logs (default: opencode-web)
+#   sync-users       Sync IAP allowed_users from config.toml
+#   teardown         DESTRUCTIVE: tear down LB + Cloud Run services
+#
+# Commands (advanced sub-targets, called by `setup`; useful for recovery):
+#   setup-project    APIs + project IAM only
+#   setup-dns        Cross-project DNS A record only
+#   setup-lb         LB resources + URL map + IAP enable
+#   setup-auth       GCIP Google IdP + authorizedDomains + IAP gcipSettings
 
 source "$(dirname "$0")/common.sh"
 cd_project_root
@@ -17,14 +33,118 @@ PROJECT_ID="${GCP_PROJECT:-kunal-scratch}"
 REGION="${GCP_REGION:-us-central1}"
 REPO="coding-labs"
 
+# -----------------------------------------------------------------------------
+# Helpers for parsing [default.dns] from config.toml via smol-toml + bun
+# -----------------------------------------------------------------------------
+_dns_field() {
+  # $1 = field name (project_id, zone_name, base_domain, subdomain)
+  bun -e "
+    const fs = require('fs');
+    const { parse } = require('smol-toml');
+    const config = parse(fs.readFileSync('config.toml', 'utf-8'));
+    console.log(config.default?.dns?.${1} || '');
+  " 2>/dev/null
+}
+
+_require_dns_config() {
+  # Read all DNS fields and validate they're populated (not placeholder values).
+  # Sets DNS_PROJECT, ZONE_NAME, BASE_DOMAIN, SUBDOMAIN, FQDN as globals.
+  DNS_PROJECT=$(_dns_field project_id)
+  ZONE_NAME=$(_dns_field zone_name)
+  BASE_DOMAIN=$(_dns_field base_domain)
+  SUBDOMAIN=$(_dns_field subdomain)
+
+  if [[ -z "$DNS_PROJECT" || "$DNS_PROJECT" == "<DNS_PROJECT_ID>" ]]; then
+    log_error "config.toml [default.dns].project_id is not set."
+    log_error "Edit config.toml and fill in the [default.dns] block first."
+    log_error "See gcip-google-signin-setup.md for guidance."
+    return 1
+  fi
+  if [[ -z "$ZONE_NAME" || "$ZONE_NAME" == "<ZONE_NAME>" ]]; then
+    log_error "config.toml [default.dns].zone_name is not set."
+    return 1
+  fi
+  if [[ -z "$BASE_DOMAIN" || "$BASE_DOMAIN" == "<BASE_DOMAIN>" ]]; then
+    log_error "config.toml [default.dns].base_domain is not set."
+    return 1
+  fi
+  if [[ -z "$SUBDOMAIN" ]]; then
+    log_error "config.toml [default.dns].subdomain is not set."
+    return 1
+  fi
+
+  # Construct FQDN. base_domain may end with a dot (Cloud DNS convention).
+  # Strip trailing dot, concat subdomain, then re-add trailing dot.
+  FQDN="${SUBDOMAIN}.${BASE_DOMAIN%.}."
+  return 0
+}
+
+# Source .env file if present (for GOOGLE_OAUTH_CLIENT_SECRET, etc.)
+_load_env() {
+  local env_file
+  env_file="$(cd_project_root && pwd)/.env"
+  if [[ -f "$env_file" ]]; then
+    # shellcheck disable=SC1090
+    set -a
+    source "$env_file"
+    set +a
+  fi
+}
+
+# Read OAuth Client ID from config.toml [default.auth.google].client_id
+_oauth_client_id() {
+  bun -e "
+    const fs = require('fs');
+    const { parse } = require('smol-toml');
+    const config = parse(fs.readFileSync('config.toml', 'utf-8'));
+    console.log(config.default?.auth?.google?.client_id || '');
+  " 2>/dev/null
+}
+
+# Read OAuth Client Secret from environment (after _load_env has sourced .env)
+_oauth_client_secret() {
+  echo "${GOOGLE_OAUTH_CLIENT_SECRET:-}"
+}
+
+# Read deployment FQDN from config.toml [default.dns] (subdomain + base_domain)
+_deployment_fqdn() {
+  local sub base
+  sub=$(_dns_field subdomain)
+  base=$(_dns_field base_domain | sed 's/\.$//')  # strip trailing dot
+  if [[ -z "$sub" || -z "$base" ]]; then
+    return 1
+  fi
+  echo "${sub}.${base}"
+}
+
+# -----------------------------------------------------------------------------
+# Meta: full one-time bootstrap (project + DNS + LB + auth)
+# -----------------------------------------------------------------------------
 cmd_setup() {
-  log_header "Setting up Cloud infrastructure"
-  
+  log_header "Full Cloud bootstrap"
+  cmd_setup_project || return 1
+  cmd_setup_dns || return 1
+  cmd_setup_lb || return 1
+  cmd_setup_auth || return 1
+  echo ""
+  log_success "Full Cloud bootstrap complete"
+  log_info ""
+  log_info "Next steps:"
+  log_info "  1. Run: make cloud-deploy"
+  log_info "  2. Run: make cloud-sync-users"
+}
+
+# -----------------------------------------------------------------------------
+# Project bootstrap: APIs + IAM (formerly cmd_setup)
+# -----------------------------------------------------------------------------
+cmd_setup_project() {
+  log_header "Setting up Cloud project (APIs + IAM)"
+
   log_info "Project: $PROJECT_ID"
   log_info "Region: $REGION"
   log_info "Repository: $REPO"
   echo ""
-  
+
   log_info "Enabling required APIs..."
   gcloud services enable \
     cloudbuild.googleapis.com \
@@ -43,7 +163,7 @@ cmd_setup() {
   log_info "Creating IAP service identity (idempotent)..."
   gcloud beta services identity create --service=iap.googleapis.com \
     --project="$PROJECT_ID" 2>/dev/null || true
-  
+
   log_info "Creating Artifact Registry repository..."
   if gcloud artifacts repositories describe "$REPO" \
     --location="$REGION" \
@@ -57,26 +177,26 @@ cmd_setup() {
       --description="Coding Labs container images"
     log_success "Repository '$REPO' created"
   fi
-  
+
   # Get project number
   PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
-  
+
   log_info "Granting Cloud Build permissions..."
-  
+
   # Cloud Build needs run.admin to deploy
   gcloud projects add-iam-policy-binding "$PROJECT_ID" \
     --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
     --role="roles/run.admin" \
     --condition=None \
     --quiet 2>/dev/null
-  
+
   # Cloud Build needs to act as service accounts
   gcloud projects add-iam-policy-binding "$PROJECT_ID" \
     --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
     --role="roles/iam.serviceAccountUser" \
     --condition=None \
     --quiet 2>/dev/null
-  
+
   # Default compute SA is used by Cloud Build for deploy steps
   # It needs Cloud Run admin and SA user permissions
   log_info "Granting Cloud Run permissions to default compute SA..."
@@ -85,13 +205,13 @@ cmd_setup() {
     --role="roles/run.admin" \
     --condition=None \
     --quiet 2>/dev/null
-  
+
   gcloud projects add-iam-policy-binding "$PROJECT_ID" \
     --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
     --role="roles/iam.serviceAccountUser" \
     --condition=None \
     --quiet 2>/dev/null
-  
+
   # Default compute SA needs Vertex AI access for LLM calls
   log_info "Granting Vertex AI access to default compute SA..."
   gcloud projects add-iam-policy-binding "$PROJECT_ID" \
@@ -99,7 +219,7 @@ cmd_setup() {
     --role="roles/aiplatform.user" \
     --condition=None \
     --quiet 2>/dev/null
-  
+
   log_info "Checking config.toml for cross-project DNS configuration..."
   DNS_PROJECT=$(_dns_field project_id 2>/dev/null || echo '')
 
@@ -144,40 +264,54 @@ cmd_setup() {
   fi
 
   echo ""
-  log_success "Cloud infrastructure setup complete"
-  echo ""
-  log_info "Next steps:"
-  log_info "  1. Fill in config.toml [default.dns] if not done; re-run 'make cloud-setup' to grant cross-project IAM"
-  log_info "  2. Run: make cloud-setup-gcip-magiclink (enables email-link + emits Firebase config)"
-  log_info "  3. Run: make cloud-deploy"
-  log_info "  4. Run: make cloud-setup-dns"
-  log_info "  5. Run: make cloud-setup-lb"
-  log_info "  6. Manual: apply IAP gcipSettings YAML (see gcip-magiclink-setup.md Phase 4)"
-  log_info "  7. Run: make cloud-sync-iap-users"
+  log_success "Cloud project setup complete"
 }
 
+# -----------------------------------------------------------------------------
+# Deploy: build + push + deploy. Auto-supplies Firebase substitutions.
+# -----------------------------------------------------------------------------
 cmd_deploy() {
   log_header "Deploying to Cloud Run"
-  
+
   # Get git short SHA for image tagging
   local tag
   tag=$(git rev-parse --short HEAD 2>/dev/null || echo "latest")
-  
+
   log_info "Project: $PROJECT_ID"
   log_info "Region: $REGION"
   log_info "Repository: $REPO"
   log_info "Tag: $tag"
   echo ""
-  
+
+  # Auto-fetch Firebase public config so opencode-login renders the Google
+  # sign-in UI without manual substitution flags. Eliminates the recurring
+  # empty-env-var bug after redeploys.
+  log_info "Fetching current Firebase public config for substitutions..."
+  local access_token response api_key auth_domain
+  access_token=$(gcloud auth print-access-token 2>/dev/null)
+  response=$(curl -sS -H "Authorization: Bearer $access_token" \
+    -H "x-goog-user-project: $PROJECT_ID" \
+    "https://identitytoolkit.googleapis.com/admin/v2/projects/${PROJECT_ID}/config" || echo '{}')
+  api_key=$(echo "$response" | bun -e "
+    const r = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+    console.log(r.client?.apiKey || '');
+  ")
+  auth_domain="${PROJECT_ID}.firebaseapp.com"
+
+  if [[ -z "$api_key" ]]; then
+    log_warn "Firebase apiKey unavailable; opencode-login will deploy with empty FIREBASE_API_KEY env var."
+    log_warn "Run 'make cloud-setup-auth' first to ensure GCIP is configured."
+  fi
+
   log_info "Submitting build to Cloud Build..."
   echo ""
-  
+
   gcloud builds submit \
     --config=cloudbuild.yaml \
     --project="$PROJECT_ID" \
-    --substitutions="_REGION=$REGION,_REPO=$REPO,_TAG=$tag" \
+    --substitutions="_REGION=$REGION,_REPO=$REPO,_TAG=$tag,_FIREBASE_API_KEY=$api_key,_FIREBASE_AUTH_DOMAIN=$auth_domain" \
     .
-  
+
   echo ""
   log_success "Deployment complete"
   echo ""
@@ -195,7 +329,7 @@ cmd_status() {
 cmd_urls() {
   log_header "Service URLs"
   local found=false
-  
+
   echo "Midnight Infrastructure:"
   for service in midnight-node midnight-indexer midnight-proof-server; do
     url=$(gcloud run services describe "$service" \
@@ -207,7 +341,7 @@ cmd_urls() {
       found=true
     fi
   done
-  
+
   echo ""
   echo "Application Services:"
   for service in agent-registry somnia-agent sonic-agent midnight-agent store-agent payment-agent midnight-mcp evm-mcp opencode-login opencode-web; do
@@ -220,7 +354,7 @@ cmd_urls() {
       found=true
     fi
   done
-  
+
   if [[ "$found" == "false" ]]; then
     log_warn "No services found. Run: make cloud-deploy"
   fi
@@ -235,72 +369,9 @@ cmd_logs() {
     --limit=50
 }
 
-cmd_delete() {
-  log_header "Deleting Cloud Run services"
-  log_warn "This will delete all services!"
-  read -p "Are you sure? (y/N) " -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-    # Delete in reverse dependency order
-    for service in opencode-web opencode-login payment-agent store-agent midnight-agent sonic-agent midnight-mcp evm-mcp somnia-agent agent-registry midnight-indexer midnight-proof-server midnight-node; do
-      log_info "Deleting $service..."
-      gcloud run services delete "$service" \
-        --region="$REGION" \
-        --project="$PROJECT_ID" \
-        --quiet 2>/dev/null || true
-    done
-    log_success "Services deleted"
-  else
-    log_info "Cancelled"
-  fi
-}
-
 # -----------------------------------------------------------------------------
-# Helpers for parsing [default.dns] from config.toml via smol-toml + bun
+# DNS: cross-project A record from config.toml
 # -----------------------------------------------------------------------------
-_dns_field() {
-  # $1 = field name (project_id, zone_name, base_domain, subdomain)
-  bun -e "
-    const fs = require('fs');
-    const { parse } = require('smol-toml');
-    const config = parse(fs.readFileSync('config.toml', 'utf-8'));
-    console.log(config.default?.dns?.${1} || '');
-  " 2>/dev/null
-}
-
-_require_dns_config() {
-  # Read all DNS fields and validate they're populated (not placeholder values).
-  # Sets DNS_PROJECT, ZONE_NAME, BASE_DOMAIN, SUBDOMAIN, FQDN as globals.
-  DNS_PROJECT=$(_dns_field project_id)
-  ZONE_NAME=$(_dns_field zone_name)
-  BASE_DOMAIN=$(_dns_field base_domain)
-  SUBDOMAIN=$(_dns_field subdomain)
-
-  if [[ -z "$DNS_PROJECT" || "$DNS_PROJECT" == "<DNS_PROJECT_ID>" ]]; then
-    log_error "config.toml [default.dns].project_id is not set."
-    log_error "Edit config.toml and fill in the [default.dns] block first."
-    log_error "See gcip-magiclink-setup.md Phase 0 for guidance."
-    return 1
-  fi
-  if [[ -z "$ZONE_NAME" || "$ZONE_NAME" == "<ZONE_NAME>" ]]; then
-    log_error "config.toml [default.dns].zone_name is not set."
-    return 1
-  fi
-  if [[ -z "$BASE_DOMAIN" || "$BASE_DOMAIN" == "<BASE_DOMAIN>" ]]; then
-    log_error "config.toml [default.dns].base_domain is not set."
-    return 1
-  fi
-  if [[ -z "$SUBDOMAIN" ]]; then
-    log_error "config.toml [default.dns].subdomain is not set."
-    return 1
-  fi
-
-  # Construct FQDN. base_domain may end with a dot (Cloud DNS convention).
-  # Strip trailing dot, concat subdomain, then re-add trailing dot.
-  FQDN="${SUBDOMAIN}.${BASE_DOMAIN%.}."
-  return 0
-}
-
 cmd_setup_dns() {
   log_header "Setting up cross-project DNS A record"
 
@@ -341,6 +412,9 @@ cmd_setup_dns() {
   log_success "DNS A record set: $FQDN → $LB_IP"
 }
 
+# -----------------------------------------------------------------------------
+# LB: NEGs, backend services, URL map (path-routed), HTTPS proxy, cert, IAP
+# -----------------------------------------------------------------------------
 cmd_setup_lb() {
   log_header "Provisioning LB resources for opencode-web + opencode-login"
 
@@ -415,9 +489,12 @@ cmd_setup_lb() {
   done
 
   # 5) URL map with path-based routing
-  #    /login*       → opencode-login-backend
-  #    /__/auth/*    → opencode-login-backend
-  #    everything else (default) → opencode-web-backend
+  #    /login*, /config, /styles.css, /health → opencode-login-backend
+  #    everything else (default) → opencode-web-backend (IAP-protected)
+  #
+  # Note: /__/auth/* path was used by the old email-link handler.html (PR #62)
+  # but is no longer needed since the Google sign-in popup flow (PR #68) uses
+  # the firebaseapp.com handler directly.
   if ! gcloud compute url-maps describe opencode-url-map \
         --global --project="$PROJECT_ID" &>/dev/null; then
     log_info "Creating URL map: opencode-url-map"
@@ -425,15 +502,40 @@ cmd_setup_lb() {
       --default-service=opencode-web-backend \
       --global --project="$PROJECT_ID" --quiet
 
-    log_info "Adding path matcher (login + auth handlers → opencode-login-backend)"
+    log_info "Adding path matcher (login + assets → opencode-login-backend)"
     gcloud compute url-maps add-path-matcher opencode-url-map \
       --path-matcher-name=login-paths \
       --default-service=opencode-web-backend \
       --new-hosts="$CERT_DOMAIN" \
-      --backend-service-path-rules="/login=opencode-login-backend,/login/*=opencode-login-backend,/__/auth/*=opencode-login-backend" \
+      --backend-service-path-rules="/login=opencode-login-backend,/login/*=opencode-login-backend,/config=opencode-login-backend,/styles.css=opencode-login-backend,/health=opencode-login-backend" \
       --global --project="$PROJECT_ID" --quiet
   else
-    log_info "URL map opencode-url-map already exists"
+    log_info "URL map opencode-url-map already exists; checking path rules drift..."
+
+    # Existing path rules may be stale (e.g., still pointing /__/auth/* somewhere
+    # or missing /config, /styles.css, /health). Refresh idempotently.
+    EXISTING_RULES=$(gcloud compute url-maps describe opencode-url-map \
+      --global --project="$PROJECT_ID" \
+      --format='value(pathMatchers[0].pathRules[].paths.list())' 2>/dev/null)
+    EXISTING_SORTED=$(echo "$EXISTING_RULES" | tr ',' '\n' | sort -u | tr '\n' ',' | sed 's/,$//' | sed 's/^,//')
+    EXPECTED_SORTED="/config,/health,/login,/login/*,/styles.css"
+    if [[ "$EXISTING_SORTED" != "$EXPECTED_SORTED" ]]; then
+      log_warn "URL map path rules drift detected; refreshing..."
+      log_warn "  Existing: $EXISTING_SORTED"
+      log_warn "  Expected: $EXPECTED_SORTED"
+      gcloud compute url-maps remove-path-matcher opencode-url-map \
+        --path-matcher-name=login-paths \
+        --global --project="$PROJECT_ID" --quiet 2>/dev/null || true
+      gcloud compute url-maps add-path-matcher opencode-url-map \
+        --path-matcher-name=login-paths \
+        --default-service=opencode-web-backend \
+        --new-hosts="$CERT_DOMAIN" \
+        --backend-service-path-rules="/login=opencode-login-backend,/login/*=opencode-login-backend,/config=opencode-login-backend,/styles.css=opencode-login-backend,/health=opencode-login-backend" \
+        --global --project="$PROJECT_ID" --quiet
+      log_success "URL map path rules refreshed"
+    else
+      log_info "URL map path rules are up to date"
+    fi
   fi
 
   # 6) Target HTTPS proxy
@@ -472,79 +574,139 @@ cmd_setup_lb() {
   echo ""
   log_success "LB resources provisioned"
   echo ""
-  log_info "Next manual step (one-time):"
-  log_info "  Apply IAP gcipSettings YAML for the agent-flow tenantIds pattern."
-  log_info "  See gcip-magiclink-setup.md Phase 4."
-  log_info ""
-  log_info "Then bind users: make cloud-sync-iap-users"
+  log_info "Next: 'make cloud-setup-auth' to configure GCIP Google IdP +"
+  log_info "authorizedDomains + IAP gcipSettings. (Or just run 'make cloud-setup'"
+  log_info "which chains all four sub-targets.)"
 }
 
-cmd_setup_gcip_magiclink() {
-  log_header "Enabling GCIP email-link sign-in"
+# -----------------------------------------------------------------------------
+# Auth: GCIP Google IdP + authorizedDomains merge + IAP gcipSettings YAML
+# -----------------------------------------------------------------------------
+# Single function that automates everything previously manual after PR #68:
+#   - POST/PATCH defaultSupportedIdpConfigs/google.com (Google IdP enable)
+#   - PATCH config?updateMask=authorizedDomains (preserving Firebase defaults)
+#   - gcloud beta iap settings set with agent-flow gcipSettings YAML
+#
+# Inputs:
+#   - config.toml [default.auth.google].client_id  (public, committed)
+#   - $GOOGLE_OAUTH_CLIENT_SECRET from .env       (sensitive, gitignored)
+#   - config.toml [default.dns]                   (for FQDN + loginPageUri)
+# -----------------------------------------------------------------------------
+cmd_setup_auth() {
+  log_header "Configuring GCIP Google IdP + authorizedDomains + IAP gcipSettings"
 
-  log_info "Project: $PROJECT_ID"
-  echo ""
+  _load_env
 
-  ACCESS_TOKEN=$(gcloud auth print-access-token)
+  local client_id client_secret deployment_fqdn
+  client_id=$(_oauth_client_id)
+  client_secret=$(_oauth_client_secret)
+  deployment_fqdn=$(_deployment_fqdn) || {
+    log_error "Could not determine deployment FQDN from config.toml [default.dns]."
+    log_error "Ensure subdomain and base_domain are set."
+    return 1
+  }
 
-  curl -sS -X PATCH \
-    -H "Authorization: Bearer $ACCESS_TOKEN" \
-    -H "x-goog-user-project: $PROJECT_ID" \
-    -H "Content-Type: application/json" \
-    "https://identitytoolkit.googleapis.com/admin/v2/projects/${PROJECT_ID}/config?updateMask=signIn.email" \
-    -d '{"signIn":{"email":{"enabled":true,"passwordRequired":false}}}'
-
-  echo ""
-  log_success "GCIP email-link sign-in enabled in project $PROJECT_ID"
-
-  # === Emit current Firebase public config for the operator ===
-  echo ""
-  log_info "Fetching current Firebase public config..."
-  RESPONSE=$(curl -sS -H "Authorization: Bearer $ACCESS_TOKEN" \
-    -H "x-goog-user-project: $PROJECT_ID" \
-    "https://identitytoolkit.googleapis.com/admin/v2/projects/${PROJECT_ID}/config" \
-    || echo '{}')
-
-  read -r API_KEY SUBDOMAIN < <(echo "$RESPONSE" | bun -e "
-    const r = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf-8'));
-    console.log((r.client?.apiKey || '') + ' ' + (r.client?.firebaseSubdomain || ''));
-  " 2>/dev/null)
-
-  if [[ -z "$API_KEY" ]]; then
-    log_warn "Could not extract apiKey from Identity Toolkit response."
-    log_warn "Raw response (first 300 chars): ${RESPONSE:0:300}"
-    log_warn "Manually fetch from: https://console.firebase.google.com/project/$PROJECT_ID/settings/general"
-    return 0
+  if [[ -z "$client_id" || "$client_id" == "<GOOGLE_OAUTH_CLIENT_ID>" ]]; then
+    log_error "config.toml [default.auth.google].client_id is unset/placeholder."
+    log_error "See gcip-google-signin-setup.md Phase 1 for setup."
+    return 1
+  fi
+  if [[ -z "$client_secret" ]]; then
+    log_error "GOOGLE_OAUTH_CLIENT_SECRET not set in environment."
+    log_error "Copy .env.example to .env and fill in the secret."
+    log_error "See gcip-google-signin-setup.md Phase 0."
+    return 1
   fi
 
-  AUTH_DOMAIN="${SUBDOMAIN:-$PROJECT_ID}.firebaseapp.com"
+  local access_token
+  access_token=$(gcloud auth print-access-token 2>/dev/null)
+
+  # === 1. Configure Google IdP (POST first; if 409/400, PATCH) ===
+  log_info "Configuring Google IdP in GCIP..."
+  local http_code
+  http_code=$(curl -s -o /tmp/gcip_idp_resp.json -w "%{http_code}" \
+    -X POST -H "Authorization: Bearer $access_token" \
+    -H "x-goog-user-project: $PROJECT_ID" \
+    -H "Content-Type: application/json" \
+    "https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT_ID/defaultSupportedIdpConfigs?idpId=google.com" \
+    -d "{\"enabled\":true,\"clientId\":\"$client_id\",\"clientSecret\":\"$client_secret\"}")
+
+  if [[ "$http_code" =~ ^(409|400)$ ]]; then
+    log_info "  Already exists; PATCHing..."
+    curl -sX PATCH -H "Authorization: Bearer $access_token" \
+      -H "x-goog-user-project: $PROJECT_ID" \
+      -H "Content-Type: application/json" \
+      "https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT_ID/defaultSupportedIdpConfigs/google.com?updateMask=enabled,clientId,clientSecret" \
+      -d "{\"enabled\":true,\"clientId\":\"$client_id\",\"clientSecret\":\"$client_secret\"}" \
+      > /dev/null
+  fi
+  log_success "Google IdP configured"
+
+  # === 2. authorizedDomains merge ===
+  log_info "Syncing authorizedDomains (preserving defaults + adding $deployment_fqdn)..."
+  local current_domains merged
+  current_domains=$(curl -sH "Authorization: Bearer $access_token" \
+    -H "x-goog-user-project: $PROJECT_ID" \
+    "https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT_ID/config" \
+    | bun -e "
+      const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+      console.log(JSON.stringify(data.authorizedDomains || []));
+    ")
+  merged=$(echo "$current_domains" | bun -e "
+    const cur = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+    const required = ['localhost', '${PROJECT_ID}.firebaseapp.com', '${PROJECT_ID}.web.app', '$deployment_fqdn'];
+    const merged = [...new Set([...cur, ...required])];
+    console.log(JSON.stringify(merged));
+  ")
+  curl -sX PATCH -H "Authorization: Bearer $access_token" \
+    -H "x-goog-user-project: $PROJECT_ID" \
+    -H "Content-Type: application/json" \
+    "https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT_ID/config?updateMask=authorizedDomains" \
+    -d "{\"authorizedDomains\":$merged}" > /dev/null
+  log_success "authorizedDomains synced: $merged"
+
+  # === 3. IAP gcipSettings (agent-flow YAML) ===
+  log_info "Applying IAP gcipSettings (agent flow)..."
+  local project_number login_url tmp_yaml
+  project_number=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
+  # Fetch current Firebase API key for loginPageUri query string
+  local response api_key
+  response=$(curl -sH "Authorization: Bearer $access_token" \
+    -H "x-goog-user-project: $PROJECT_ID" \
+    "https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT_ID/config" || echo '{}')
+  api_key=$(echo "$response" | bun -e "
+    const r = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+    console.log(r.client?.apiKey || '');
+  ")
+  if [[ -z "$api_key" ]]; then
+    log_warn "Could not fetch Firebase apiKey. IAP gcipSettings YAML cannot include the apiKey query parameter."
+    log_warn "loginPageUri will be incomplete; IAP may reject."
+    return 1
+  fi
+  login_url="https://${deployment_fqdn}/login?apiKey=${api_key}"
+  tmp_yaml=$(mktemp)
+  cat > "$tmp_yaml" <<EOF
+accessSettings:
+  gcipSettings:
+    tenantIds:
+    - _${project_number}
+    loginPageUri: ${login_url}
+EOF
+  gcloud beta iap settings set "$tmp_yaml" \
+    --project="$PROJECT_ID" \
+    --resource-type=backend-services \
+    --service=opencode-web-backend > /dev/null
+  rm -f "$tmp_yaml"
+  log_success "IAP gcipSettings applied (tenantIds: [_${project_number}])"
 
   echo ""
-  log_success "Firebase public config (use as Cloud Build substitutions):"
-  echo ""
-  echo "  _FIREBASE_API_KEY=$API_KEY"
-  echo "  _FIREBASE_AUTH_DOMAIN=$AUTH_DOMAIN"
-  echo "  _FIREBASE_PROJECT_ID=$PROJECT_ID"
-  echo ""
-  log_info "Pass these to Cloud Build:"
-  echo ""
-  echo "  gcloud builds submit --substitutions=\\"
-  echo "    _FIREBASE_API_KEY=$API_KEY,\\"
-  echo "    _FIREBASE_AUTH_DOMAIN=$AUTH_DOMAIN,\\"
-  echo "    _FIREBASE_PROJECT_ID=$PROJECT_ID,..."
-  echo ""
-  log_info "Or set them in your shell environment:"
-  echo ""
-  echo "  export _FIREBASE_API_KEY=$API_KEY"
-  echo "  export _FIREBASE_AUTH_DOMAIN=$AUTH_DOMAIN"
-  echo "  export _FIREBASE_PROJECT_ID=$PROJECT_ID"
-  echo ""
-  log_info "These values are PUBLIC by Firebase design — safe to commit/share."
-  log_info "Security comes from authorized-domain whitelist + Security Rules,"
-  log_info "not from secrecy of the apiKey."
+  log_success "Auth setup complete"
 }
 
-cmd_sync_iap_users() {
+# -----------------------------------------------------------------------------
+# Sync IAP allowed_users from config.toml
+# -----------------------------------------------------------------------------
+cmd_sync_users() {
   log_header "Syncing IAP users from config.toml to opencode-web-backend"
 
   # Parse allowed_users from config.toml using bun + smol-toml
@@ -626,18 +788,21 @@ cmd_sync_iap_users() {
   log_success "IAP users synced to opencode-web-backend"
 }
 
-cmd_teardown_lb() {
-  log_header "Tearing down LB resources (DESTRUCTIVE)"
-
-  log_warn "This will REMOVE the LB and BREAK the deployment."
-  log_warn "Cloud DNS records and Cloud Run services are NOT touched."
-  read -r -p "Are you sure? [y/N]: " confirm
-  if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+# -----------------------------------------------------------------------------
+# Teardown: LB resources + Cloud Run services (single confirmation)
+# -----------------------------------------------------------------------------
+cmd_teardown() {
+  log_header "Tearing down ALL infrastructure (DESTRUCTIVE)"
+  log_warn "This will REMOVE the LB AND all Cloud Run services."
+  log_warn "Cloud DNS records and the Artifact Registry repo are NOT touched."
+  read -r -p "Are you sure? Type 'yes' to confirm: " confirm
+  if [[ "$confirm" != "yes" ]]; then
     log_info "Cancelled"
     return 0
   fi
 
-  # Delete in reverse dependency order; ignore errors if resource is absent
+  # 1. LB resources (delete in reverse dependency order; ignore errors)
+  log_info "Removing LB resources..."
   for cmd in \
     "gcloud compute forwarding-rules delete opencode-fwd-rule --global --quiet --project=$PROJECT_ID" \
     "gcloud compute target-https-proxies delete opencode-https-proxy --global --quiet --project=$PROJECT_ID" \
@@ -649,18 +814,39 @@ cmd_teardown_lb() {
     "gcloud compute network-endpoint-groups delete opencode-login-neg --region=$REGION --quiet --project=$PROJECT_ID" \
     "gcloud compute ssl-certificates delete opencode-web-cert --global --quiet --project=$PROJECT_ID" \
     "gcloud compute addresses delete opencode-web-lb-ip --global --quiet --project=$PROJECT_ID"; do
-    log_info "Running: $cmd"
-    eval "$cmd" 2>/dev/null || true
+    eval "$cmd 2>/dev/null || true"
   done
+  log_success "LB resources removed"
+
+  # 2. Cloud Run services
+  log_info "Removing Cloud Run services..."
+  for service in opencode-web opencode-login payment-agent store-agent midnight-agent sonic-agent midnight-mcp evm-mcp somnia-agent agent-registry midnight-indexer midnight-proof-server midnight-node; do
+    gcloud run services delete "$service" --region="$REGION" --project="$PROJECT_ID" --quiet 2>/dev/null || true
+  done
+  log_success "Cloud Run services removed"
 
   echo ""
-  log_success "LB resources removed"
+  log_success "Full teardown complete"
 }
 
-# Main
+# -----------------------------------------------------------------------------
+# Dispatcher
+# -----------------------------------------------------------------------------
 case "${1:-}" in
   setup)
     cmd_setup
+    ;;
+  setup-project)
+    cmd_setup_project
+    ;;
+  setup-dns)
+    cmd_setup_dns
+    ;;
+  setup-lb)
+    cmd_setup_lb
+    ;;
+  setup-auth)
+    cmd_setup_auth
     ;;
   deploy)
     cmd_deploy
@@ -674,40 +860,27 @@ case "${1:-}" in
   logs)
     cmd_logs "${2:-}"
     ;;
-  delete)
-    cmd_delete
+  sync-users)
+    cmd_sync_users
     ;;
-  setup-dns)
-    cmd_setup_dns
-    ;;
-  setup-lb)
-    cmd_setup_lb
-    ;;
-  setup-gcip-magiclink)
-    cmd_setup_gcip_magiclink
-    ;;
-  sync-iap-users)
-    cmd_sync_iap_users
-    ;;
-  teardown-lb)
-    cmd_teardown_lb
+  teardown)
+    cmd_teardown
     ;;
   *)
     show_usage "cloud.sh" "
-  setup                  One-time setup (APIs, Artifact Registry, IAM)
-  deploy                 Build and deploy to Cloud Run
-  status                 Show Cloud Run service status
-  urls                   Show service URLs
-  logs [svc]             View logs (default: opencode-web)
-  delete                 Delete all Cloud Run services
+  setup            One-time meta bootstrap (project + dns + lb + auth)
+  deploy           Build and deploy to Cloud Run (auto Firebase substitutions)
+  status           Show Cloud Run service status
+  urls             Show service URLs
+  logs [svc]       View logs (default: opencode-web)
+  sync-users       Sync IAP allowed_users from config.toml
+  teardown         DESTRUCTIVE: tear down LB + Cloud Run services
 
-  setup-dns              Create cross-project DNS A record from config.toml
-  setup-lb               Provision LB resources (NEGs, backend services,
-                         URL map with path routing, SSL cert, fwd rule)
-  setup-gcip-magiclink   Enable GCIP email-link sign-in in this project
-  sync-iap-users         Sync IAP allowed_users from config.toml to the
-                         opencode-web-backend backend service
-  teardown-lb            DESTRUCTIVE: remove all LB resources
+Advanced sub-targets (called by 'setup'; useful for recovery):
+  setup-project    APIs + project IAM only
+  setup-dns        Cross-project DNS A record only
+  setup-lb         LB resources + URL map + IAP enable
+  setup-auth       GCIP Google IdP + authorizedDomains + IAP gcipSettings
 
 Environment variables:
   GCP_PROJECT  GCP project ID (default: kunal-scratch)


### PR DESCRIPTION
## Summary

Comprehensive overhaul of cloud bootstrap automation. Eliminates the recurring "manual config band-aid" pattern that's plagued the IAP+GCIP+Google-OAuth bring-up across PRs #62 / #64 / #66 / #68. After this PR lands, operators run **3 commands** (`cloud-setup` → `cloud-deploy` → `cloud-sync-users`) with **no manual gcloud follow-ups** across redeploys.

## Linked issues

- Closes #69
- Supersedes (folded in, not separately filed): Issues B, C, D refined, K, L per #69 body

## What's in this PR

### `scripts/cloud.sh` (~80% rewrite)
- New meta `cmd_setup` chains 4 sub-functions (project + dns + lb + auth)
- New `cmd_setup_auth` — automates Google IdP, authorizedDomains merge, IAP gcipSettings YAML
- New helpers: `_load_env`, `_oauth_client_id`, `_oauth_client_secret`, `_deployment_fqdn`
- `cmd_deploy` now auto-fetches Firebase config and passes as Cloud Build substitutions (eliminates empty-env-var bug)
- `cmd_setup_lb` URL map path rules updated (drops `/__/auth/*`, adds `/config`, `/styles.css`, `/health`); idempotent drift detection refreshes stale rules
- Renamed `cmd_setup` → `cmd_setup_project`
- Renamed `cmd_sync_iap_users` → `cmd_sync_users`
- Merged `cmd_teardown_lb` + `cmd_delete` → `cmd_teardown`
- Deleted stale `cmd_setup_gcip_magiclink`

### `Makefile`
- Consolidated from 11 surfaced cloud-* targets to 7 surfaced + 4 advanced sub-targets
- Help section leads with the 3-command operator workflow

### `config.toml`
- New `[default.auth.google]` section for OAuth `client_id` (public, committed)

### `.env.example` (new) + `.gitignore` (clarifying comment)
- `GOOGLE_OAUTH_CLIENT_SECRET` lives in `.env` (gitignored; pattern was already present)
- `.env.example` is the committed template

### Documentation
- `gcip-google-signin-setup.md` rewritten for v3 (fully automated) workflow
- `README.md` operator section updated with new target table
- `.context.md` migration entry (session 27)
- `cloudbuild.yaml` substitutions header comments updated (auto-supplied note)

## Pre-merge checklist (operator)

- [ ] Operator fills in `config.toml [default.auth.google].client_id` with their value (e.g. `954632890046-...apps.googleusercontent.com` per current setup)
- [ ] Operator copies `.env.example` to `.env` and fills in `GOOGLE_OAUTH_CLIENT_SECRET`
- [ ] Operator marks PR ready and merges
- [ ] Operator runs `make cloud-deploy` (no manual env-var fix needed)
- [ ] Operator runs `make cloud-sync-users`
- [ ] End-to-end browser test: visit `https://dcoder.kunall.demo.altostrat.com/`, sign in via Google, land on protected app

## Validation (static only — per operator's choice for fast iteration)

- ✅ `bash -n scripts/cloud.sh` (exit 0)
- ✅ `python3 -c "import yaml; yaml.safe_load(open('cloudbuild.yaml'))"`
- ✅ `python3 -c "import tomllib; tomllib.load(open('config.toml','rb'))"`
- ✅ `make help` renders cleanly with new structure
- ✅ `grep -rE "cmd_setup_gcip_magiclink|sync-iap-users|teardown-lb|cmd_delete|cloud-delete" scripts/ Makefile gcip-*.md README.md cloudbuild.yaml config.toml` returns zero matches (all matches now confined to .context.md migration log, where they are descriptive references)

Live-deploy validation deferred to operator's post-merge `make cloud-deploy`.

## Commit log

- `refactor(cloud.sh): consolidate bootstrap functions and automate Firebase substitutions`
- `refactor(makefile): consolidate cloud-* targets to 7 surfaced + 4 advanced`
- `feat(config): add [default.auth.google] section and .env.example template`
- `docs(cloudbuild): update comments for auto-supplied Firebase substitutions`
- `docs: rewrite operator workflow for consolidated cloud bootstrap`
