### PR TITLE
fix(opencode-login): use gcip-iap library for IAP+GCIP redirect-back (#71)

### DIFF
--- a/onchain-agents/coding-labs/packages/opencode-login/public/index.html
+++ b/onchain-agents/coding-labs/packages/opencode-login/public/index.html
@@ -684,18 +684,27 @@
     </script>
 
     <!--
-      Google sign-in module (issue #67).
-      Loads Firebase JS SDK from the official CDN, fetches public config
-      from /config, and wires up the "Sign in with Google" button using
-      signInWithPopup against the GCIP-configured Google IdP.
+      Google sign-in module (issue #67, fix issue #71).
+      Uses Google's official `gcip-iap` library to drive the IAP+GCIP
+      "agent flow" redirect-back contract. The library reads the IAP-passed
+      query params (apiKey, mode, tid, redirect_uri, state), invokes our
+      `startSignIn` handler (still backed by signInWithPopup), and POSTs
+      `id_token` + `state` to IAP's `redirect_uri` so IAP can mint its
+      session cookie and bounce the user back to the original protected URL.
     -->
     <script type="module">
-      import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.0.2/firebase-app.js';
+      import { initializeApp, getApp, getApps } from 'https://www.gstatic.com/firebasejs/11.0.2/firebase-app.js';
       import {
         getAuth,
         GoogleAuthProvider,
         signInWithPopup,
       } from 'https://www.gstatic.com/firebasejs/11.0.2/firebase-auth.js';
+      import * as ciap from 'https://cdn.jsdelivr.net/npm/gcip-iap@2.0.0/+esm';
+
+      // Agent-flow tenant ID per IAP+GCIP convention: `_<project_number>`.
+      // Mirrors the value in `gcipSettings.tenantIds` (PR #62) for the
+      // kunal-scratch project (project number 550614207330).
+      const AGENT_TENANT_ID = '_550614207330';
 
       function showError(msg) {
         const errEl = document.getElementById('signin-error');
@@ -709,10 +718,24 @@
         errEl.textContent = '';
       }
 
-      async function initGoogleAuth() {
+      // Fetch a fresh app instance for a given (apiKey, tenantId) tuple.
+      // gcip-iap calls `getAuth(apiKey, tenantId)` per tenant; we keep one
+      // Firebase app per tuple to keep auth state isolated.
+      function getOrCreateApp(firebaseConfig, tenantId) {
+        const appName = `auth-${firebaseConfig.apiKey}-${tenantId || 'default'}`;
+        if (getApps().some((a) => a.name === appName)) {
+          return getApp(appName);
+        }
+        return initializeApp(firebaseConfig, appName);
+      }
+
+      async function init() {
         let config;
         try {
           const response = await fetch('/config');
+          if (!response.ok) {
+            throw new Error(`/config returned HTTP ${response.status}`);
+          }
           config = await response.json();
         } catch (err) {
           console.error('[opencode-login] Failed to fetch /config:', err);
@@ -728,48 +751,95 @@
           return;
         }
 
-        const app = initializeApp(config.firebase);
-        const auth = getAuth(app);
+        const firebaseConfig = config.firebase;
 
-        const signInBtn = document.getElementById('google-signin-btn');
+        // gcip-iap config map: keyed by API key, then per-tenant signInOptions.
+        // Single-tenant agent-flow setup; only Google is configured as IdP.
+        const ciapConfig = {
+          [firebaseConfig.apiKey]: {
+            authDomain: firebaseConfig.authDomain,
+            tenants: {
+              [AGENT_TENANT_ID]: {
+                signInOptions: ['google.com'],
+              },
+            },
+          },
+        };
 
-        signInBtn.addEventListener('click', async () => {
-          clearError();
-          const provider = new GoogleAuthProvider();
-          try {
-            // signInWithPopup uses GCIP's configured Google IdP.
-            // GCIP routes to the cross-project OAuth client (External user type)
-            // and returns a Firebase ID token. The IAP↔GCIP agent flow
-            // (gcipSettings.tenantIds: ["_<project_number>"]) accepts this token.
-            const result = await signInWithPopup(auth, provider);
-            const idToken = await result.user.getIdToken();
-            console.log('[opencode-login] Sign-in succeeded for', result.user.email);
+        const handler = {
+          languageCode: 'en',
 
-            // Standard IAP+GCIP redirect-back: navigate to the original target.
-            // IAP detects the GCIP session via Firebase's auth-state cookies
-            // (set by signInWithPopup) and completes its session establishment
-            // on the next request to a protected URL.
-            // Try to extract original URL from URL params (IAP passes 'continueUri'
-            // or 'state' in some configurations); fall back to root.
-            const params = new URLSearchParams(window.location.search);
-            const continueUri = params.get('continueUri') || params.get('state') || '/';
-            window.location.href = continueUri;
-          } catch (err) {
-            console.error('[opencode-login] Google sign-in failed:', err);
-            if (err.code === 'auth/popup-closed-by-user') {
-              // User cancelled; no error needed
-              return;
+          getAuth: (apiKey, tenantId) => {
+            const app = getOrCreateApp(firebaseConfig, tenantId);
+            const auth = getAuth(app);
+            if (tenantId) {
+              auth.tenantId = tenantId;
             }
-            if (err.code === 'auth/popup-blocked') {
-              showError('Popup blocked. Please allow popups for this site and try again.');
-              return;
-            }
-            showError(err.message || 'Sign-in failed. Try again.');
-          }
-        });
+            return auth;
+          },
+
+          // Single-tenant agent flow — auto-select the only configured tenant.
+          selectTenant: (_projectConfig, tenantIds) => {
+            return Promise.resolve({
+              tenantId: tenantIds[0],
+              providerIds: ['google.com'],
+            });
+          },
+
+          // Wait for the user to click "Sign in with Google", then run
+          // signInWithPopup. Returning the UserCredential hands control back
+          // to gcip-iap, which will POST id_token + state to IAP's redirect_uri.
+          startSignIn: (auth) => {
+            return new Promise((resolve, reject) => {
+              const signInBtn = document.getElementById('google-signin-btn');
+
+              const onClick = async () => {
+                signInBtn.removeEventListener('click', onClick);
+                clearError();
+                try {
+                  const result = await signInWithPopup(auth, new GoogleAuthProvider());
+                  console.log(
+                    '[opencode-login] Sign-in succeeded for',
+                    result.user && result.user.email
+                  );
+                  resolve(result);
+                } catch (err) {
+                  console.error('[opencode-login] Google sign-in failed:', err);
+                  // Re-attach listener for retry on recoverable errors.
+                  signInBtn.addEventListener('click', onClick);
+                  if (err.code === 'auth/popup-closed-by-user') {
+                    // User cancelled; no error needed and no rejection
+                    // (rejecting would surface as a handler error).
+                    return;
+                  }
+                  if (err.code === 'auth/popup-blocked') {
+                    showError('Popup blocked. Please allow popups for this site and try again.');
+                    return;
+                  }
+                  showError(err.message || 'Sign-in failed. Try again.');
+                  reject(err);
+                }
+              };
+
+              signInBtn.addEventListener('click', onClick);
+            });
+          },
+
+          completeSignOut: () => Promise.resolve(),
+
+          handleError: (error) => {
+            console.error('[opencode-login] gcip-iap handler error:', error);
+            showError((error && error.message) || 'Sign-in failed. Try again.');
+          },
+        };
+
+        // Start the gcip-iap flow — handles IAP query params, sign-in, and
+        // the redirect-back POST to IAP's redirect_uri automatically.
+        const ciapInstance = new ciap.Authentication(handler);
+        ciapInstance.start();
       }
 
-      document.addEventListener('DOMContentLoaded', initGoogleAuth);
+      document.addEventListener('DOMContentLoaded', init);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Replaces the broken manual IAP+GCIP redirect-back logic in opencode-login (introduced by PR #68) with Google's official `gcip-iap` library. Fixes the "user stuck on login page after Google sign-in" bug reported during real-world testing.

## Linked issues

- Closes #71

## Background

After PR #68 pivoted from email-link to Google sign-in, the JS used:

```js
const continueUri = params.get('continueUri') || params.get('state') || '/';
window.location.href = continueUri;
```

This is wrong: `state` is a signed JWT, not a URL; treating it as a URL produces malformed navigation → Chrome error page → user stuck.

The fix uses the `gcip-iap` library, which handles the IAP+GCIP "agent flow" redirect contract automatically (POSTs `id_token` + `state` back to IAP's `redirect_uri`).

## What's in this PR

- `packages/opencode-login/public/index.html`: refactored the inline `<script type="module">` block from manual `signInWithPopup` orchestration (with broken redirect) to a `gcip-iap` handler-based flow.
  - New imports: `getApp`/`getApps` (firebase-app) and `gcip-iap` (`ciap.Authentication`).
  - Handler implements `getAuth`, `selectTenant` (single-tenant agent flow), `startSignIn` (still uses `signInWithPopup` inside), `completeSignOut`, `handleError`, `languageCode`.
  - The `#google-signin-btn` UI, `#signin-error` element, and `showError` / `clearError` helpers are unchanged.
  - Error handling for `auth/popup-closed-by-user` and `auth/popup-blocked` is preserved inside the new `startSignIn` handler.
  - Agent-flow tenant ID `_550614207330` is hardcoded (matches `gcipSettings.tenantIds` from PR #62 — project number prefixed with `_`).

## CDN choice (notable)

Per the issue, the spec suggested gstatic-hosted gcip-iap. **gstatic does NOT host gcip-iap** (`https://www.gstatic.com/firebasejs/12.0.0/gcip-iap.js` returns 404; same for 11.0.2). gcip-iap is published on npm and CDN'd via jsDelivr. The chosen pinned URL:

```
https://cdn.jsdelivr.net/npm/gcip-iap@2.0.0/+esm
```

`gcip-iap@2.0.0` peer-deps `firebase ^9.8.3`; the existing Firebase 11.0.2 modular SDK satisfies this (modular API is stable across 9 → 11). The jsDelivr ESM bundle inlines the polyfill peers (`whatwg-fetch`, `url-polyfill`, `promise-polyfill`) automatically.

## Validation

All static checks pass against the workspace HEAD:

| Check | Expected | Actual |
|---|---|---|
| `node --check` on extracted module | exit 0 | ✅ exit 0 |
| `grep -c "gcip-iap"` | ≥ 1 | 7 |
| `grep -cE "ciap.Authentication\|new ciap"` | ≥ 1 | 1 |
| `grep -c "signInWithPopup"` (still used in `startSignIn`) | ≥ 1 | 4 |
| Broken redirect pattern `params.get('state') \|\| '/'` | 0 | 0 ✅ gone |
| `grep -c "google-signin-btn"` | ≥ 1 | 2 |

Diff stats: `1 file changed, 115 insertions(+), 45 deletions(-)`.

## What's NOT in this PR

- No documentation update to `gcip-google-signin-setup.md` (out of scope per issue; can follow up).
- No changes to other packages or to the IAP/GCIP Terraform.
- No automated tests (consistent with the existing "no test infra for opencode-login" precedent — operator validates via browser).

## Pre-merge checklist

- [ ] Operator reviews diff and marks PR ready for review.
- [ ] Operator merges (squash, matches project convention).
- [ ] Operator runs `make cloud-deploy` (auto-supplies Firebase substitutions per PR #70).
- [ ] Operator visits `https://dcoder.kunall.demo.altostrat.com/` in incognito and confirms end-to-end sign-in works (popup → signed in on protected app, **NO** `chrome-error://chromewebdata/`).

## Status

🟡 **DRAFT** — awaiting operator review + post-merge live validation.
