### PR TITLE
fix(setup): automate IAP->Cloud Run invoker grant + iap.googleapis.com in authorizedDomains

### DIFF
--- a/onchain-agents/coding-labs/cloudbuild.yaml
+++ b/onchain-agents/coding-labs/cloudbuild.yaml
@@ -865,14 +865,11 @@ steps:
           --max-instances=10 \
           --set-env-vars="NODE_ENV=production,GOOGLE_CLOUD_PROJECT=${PROJECT_ID},GOOGLE_CLOUD_LOCATION=global,AGENT_REGISTRY_URL=$${REGISTRY_URL},SOMNIA_AGENT_URL=$${SOMNIA_URL},SONIC_AGENT_URL=$${SONIC_URL},MIDNIGHT_AGENT_URL=$${MIDNIGHT_URL},STORE_AGENT_URL=$${STORE_URL},PAYMENT_AGENT_URL=$${PAYMENT_URL},SECURITY_AGENT_URL=$${SECURITY_URL},LOGIN_PAGE_URL=$${LOGIN_URL}"
 
-  # NOTE: The previous `setup-iap` step (which granted the IAP service agent
-  # run.invoker via Cloud Run direct IAP) has been REMOVED.
-  #
-  # In the new architecture, IAP is enabled at the LB backend service
-  # (opencode-web-backend), and the LB serverless NEG service agent (NOT the
-  # IAP service agent) needs run.invoker on the Cloud Run service. That binding
-  # is provisioned by `make cloud-setup-lb` / managed manually one-time.
-  # See gcip-magiclink-setup.md.
+  # NOTE: The IAP service agent (service-<PROJECT_NUMBER>@gcp-sa-iap.iam.gserviceaccount.com)
+  # requires roles/run.invoker on opencode-web Cloud Run service so IAP can
+  # forward authenticated user requests to the backend. This binding is granted
+  # automatically by cmd_setup_lb in scripts/cloud.sh (run via `make cloud-setup`
+  # or `make cloud-setup-lb`). See gcip-google-signin-setup.md for the full flow.
 
   # ===========================================================================
   # UPDATE agent-registry with agent URLs

--- a/onchain-agents/coding-labs/gcip-google-signin-setup.md
+++ b/onchain-agents/coding-labs/gcip-google-signin-setup.md
@@ -113,7 +113,9 @@ make cloud-sync-users   # ~30 sec
 1. `cloud-setup-project` — APIs + project IAM (idempotent)
 2. `cloud-setup-dns` — Cross-project A record from `[default.dns]`
 3. `cloud-setup-lb` — NEGs + backend services + URL map + cert + IAP enable
-4. `cloud-setup-auth` — Google IdP + authorizedDomains merge + IAP gcipSettings
+   + IAP service agent `roles/run.invoker` grant on `opencode-web`
+4. `cloud-setup-auth` — Google IdP + authorizedDomains merge (incl.
+   `iap.googleapis.com` for the gcip-iap redirect-back POST) + IAP gcipSettings
 
 Each sub-target is also runnable individually for surgical recovery, e.g.,
 if the LB cert needs to be re-provisioned: `make cloud-setup-lb`.

--- a/onchain-agents/coding-labs/scripts/cloud.sh
+++ b/onchain-agents/coding-labs/scripts/cloud.sh
@@ -578,6 +578,31 @@ cmd_setup_lb() {
     --service=opencode-web-backend \
     --project="$PROJECT_ID" 2>/dev/null || log_warn "IAP enable skipped (already enabled or requires manual gcipSettings step)"
 
+  # 8b) Grant IAP service agent run.invoker on opencode-web Cloud Run service.
+  #     IAP forwards requests using its service agent identity. Without this
+  #     binding, Cloud Run rejects with 403 "client does not have permission".
+  #     opencode-login already has allUsers:run.invoker (deployed --allow-unauth);
+  #     opencode-web is correctly hardened to --no-allow-unauthenticated, so this
+  #     compensating grant is required. See issue #75.
+  local project_number iap_sa
+  project_number=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)' 2>/dev/null)
+  if [[ -z "$project_number" ]]; then
+    log_warn "Could not determine project number; skipping IAP service agent invoker grant"
+  else
+    iap_sa="service-${project_number}@gcp-sa-iap.iam.gserviceaccount.com"
+    log_info "Granting roles/run.invoker to IAP service agent on opencode-web"
+    if gcloud run services add-iam-policy-binding opencode-web \
+         --region="$REGION" \
+         --project="$PROJECT_ID" \
+         --member="serviceAccount:${iap_sa}" \
+         --role="roles/run.invoker" \
+         --quiet >/dev/null 2>&1; then
+      log_success "IAP service agent granted run.invoker on opencode-web"
+    else
+      log_warn "Failed to grant invoker on opencode-web (may already exist or insufficient permissions)"
+    fi
+  fi
+
   echo ""
   log_success "LB resources provisioned"
   echo ""
@@ -715,9 +740,18 @@ EOF_BODY
     return 1
   fi
 
+  # Required defaults:
+  #   - localhost: Firebase dev convenience
+  #   - <PROJECT_ID>.firebaseapp.com / .web.app: Firebase Hosting defaults
+  #   - $deployment_fqdn: the LB hostname users actually visit
+  #   - iap.googleapis.com: required for IAP+GCIP redirect-back POST. The
+  #     gcip-iap library validates the IAP handler URL
+  #     (https://iap.googleapis.com/v1beta1/gcip/resources/<RID>:handleRedirect)
+  #     against authorizedDomains BEFORE POSTing the ID token; without this
+  #     entry sign-in fails with "Unauthorized domain". See issue #76.
   merged=$(echo "$current_domains" | bun -e "
     const cur = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
-    const required = ['localhost', '${PROJECT_ID}.firebaseapp.com', '${PROJECT_ID}.web.app', '$deployment_fqdn'];
+    const required = ['localhost', '${PROJECT_ID}.firebaseapp.com', '${PROJECT_ID}.web.app', '$deployment_fqdn', 'iap.googleapis.com'];
     const merged = [...new Set([...cur, ...required])];
     console.log(JSON.stringify(merged));
   ")


### PR DESCRIPTION
## Summary

End-to-end Google sign-in succeeded in production today for the first time
(after the multi-week saga across PRs #62, #66, #64, #68, #70, #72), but
**two manual commands** were required to unblock the final 403/Unauthorized-
domain failures. Those commands aren't in `scripts/cloud.sh` — meaning a
fresh `make cloud-setup` from a wiped state would reproduce the same blocker.

This PR encodes both fixes so the bootstrap is end-to-end automated, per
the operator's standing rule: *"No manual fixes. All config must be
automated by `scripts/cloud.sh`; no `gcloud run services update` band-aids."*

Closes #75
Closes #76

## The two manual commands this PR replaces

### 1. IAP service agent → opencode-web invoker (issue #75)

Manual command that unblocked sign-in today:
```bash
gcloud run services add-iam-policy-binding opencode-web \
  --region=us-central1 --project=kunal-scratch \
  --member=serviceAccount:service-550614207330@gcp-sa-iap.iam.gserviceaccount.com \
  --role=roles/run.invoker
```

`opencode-web` is correctly hardened to `--no-allow-unauthenticated`
(cloudbuild.yaml line 859), so `allUsers:roles/run.invoker` does NOT
exist. Without the IAP service agent binding, IAP forwards to Cloud Run
return `403 "Your client does not have permission to get URL / from this
server"` *after* a successful sign-in. The cloudbuild.yaml comment at the
old lines 868-875 even acknowledged this binding was *"managed manually
one-time"* — that note is updated in this PR to reflect the now-automated
behavior.

### 2. `iap.googleapis.com` in authorizedDomains (issue #76)

Manual PATCH that unblocked sign-in today:
```bash
curl -sX PATCH \
  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
  -H "x-goog-user-project: kunal-scratch" \
  -H "Content-Type: application/json" \
  "https://identitytoolkit.googleapis.com/admin/v2/projects/kunal-scratch/config?updateMask=authorizedDomains" \
  -d '{"authorizedDomains":["dcoder.kunall.demo.altostrat.com","localhost","kunal-scratch.firebaseapp.com","kunal-scratch.web.app","iap.googleapis.com"]}'
```

The `gcip-iap` library (added in PR #72) validates the IAP handler URL
(`https://iap.googleapis.com/v1beta1/gcip/resources/<RID>:handleRedirect`)
against Firebase's `authorizedDomains` BEFORE POSTing the ID token. Without
`iap.googleapis.com` in the list, the library throws "Unauthorized domain"
and sign-in fails.

## Changes

| File | Change |
|---|---|
| `scripts/cloud.sh` | **Part A:** New step 8b in `cmd_setup_lb` — derives `service-<PROJECT_NUMBER>@gcp-sa-iap.iam.gserviceaccount.com` from `gcloud projects describe` and grants `roles/run.invoker` on `opencode-web`. Idempotent. |
| `scripts/cloud.sh` | **Part B:** Added `'iap.googleapis.com'` to the `required` array in `cmd_setup_auth` (the existing read-modify-write merge picks it up). |
| `cloudbuild.yaml` | **Part C:** Replaced the stale "managed manually one-time" comment (which also referenced the obsolete `gcip-magiclink-setup.md`) with one that points to `gcip-google-signin-setup.md` and reflects the now-automated grant. |
| `gcip-google-signin-setup.md` | **Part D:** Refreshed the `cloud-setup-lb` / `cloud-setup-auth` summary lines to mention the new responsibilities. |

## Verification

Both bindings were verified **live in production today** before this PR was
written:
- `gcloud run services get-iam-policy opencode-web --region=us-central1 --project=kunal-scratch` shows `serviceAccount:service-550614207330@gcp-sa-iap.iam.gserviceaccount.com → roles/run.invoker`.
- Identity Toolkit Admin API GET on `projects/kunal-scratch/config` shows `iap.googleapis.com` in `authorizedDomains`.
- Browser sign-in flow completes end-to-end (IdP → IAP redirect-back → opencode-web).

## Idempotency

- `gcloud run services add-iam-policy-binding` returns success when the
  binding already exists. The new block also wraps the call in a
  conditional with a `log_warn` fallback, so a missing IAM permission
  doesn't fail the whole `cmd_setup_lb` flow.
- The `authorizedDomains` PATCH is already idempotent via the existing
  read-merge-write logic (`Set` dedupe in the `bun` merge step).
- Re-running `make cloud-setup` against the current live state should
  complete successfully with no errors and no spurious changes.

## Regression test scenario for future operators

A future operator should be able to:
1. Manually remove the IAP SA invoker binding on `opencode-web`
   (`gcloud run services remove-iam-policy-binding ...`).
2. Manually PATCH `authorizedDomains` to remove `iap.googleapis.com`.
3. Run `make cloud-setup`.
4. Sign in successfully via `https://<deployment_fqdn>/` with **no further
   manual intervention**.

Both bindings should be re-established by `cmd_setup_lb` and `cmd_setup_auth`
respectively.

## Architecture context

- GCIP+IAP at LB backend (`opencode-web-backend`) → Serverless NEG → Cloud Run `opencode-web`
- Cloud Run ingress = `internal-and-cloud-load-balancing`, deploy = `--no-allow-unauthenticated`
- `opencode-login` is the public sign-in page (`allUsers:roles/run.invoker`, no IAP)
- GCIP runs in "agent flow" mode (`gcipSettings.tenantIds: ["_550614207330"]`)
- With GCIP-backed IAP, IAM bindings on the IAP backend service are bypassed
  for user authorization (per Google docs); user-level allowlisting is in
  app code via `config.toml [default.auth].allowed_users`

## Test status

- `bash` syntax of `scripts/cloud.sh` is preserved (no parse errors; diff is
  surgical: a single new conditional block in `cmd_setup_lb` and one
  additional element in an existing JS array literal).
- `cloudbuild.yaml` change is a comment-only edit.
- `gcip-google-signin-setup.md` change is a 2-line docs refresh.
- No project-level test infrastructure exercises these specific files; the
  monorepo `go test ./...` at the workspace root reports "no packages to
  test" and is not relevant to the changed surface.

## Related references

- The `cloudbuild.yaml` comment at the old lines 868-875 explicitly flagged
  that the missing IAP-SA invoker grant was managed manually. This PR
  closes that gap.
- PR #72 introduced the `gcip-iap` library that surfaced the
  `iap.googleapis.com` `authorizedDomains` requirement.